### PR TITLE
feat: enable logout on verify page

### DIFF
--- a/frontend/cloud-ui/src/app/forgot/forgot.component.html
+++ b/frontend/cloud-ui/src/app/forgot/forgot.component.html
@@ -43,12 +43,6 @@
                 >Back to login</a
               >
             </p>
-            <p class="text-sm text-center font-light text-gray-500 dark:text-gray-400">
-              Don’t have an account yet?<br />
-              <a routerLink="/register" class="font-medium text-primary-600 hover:underline dark:text-primary-500"
-                >Sign up</a
-              >
-            </p>
           </form>
         }
       </div>

--- a/frontend/cloud-ui/src/app/login/login.component.html
+++ b/frontend/cloud-ui/src/app/login/login.component.html
@@ -67,12 +67,6 @@
             class="w-full text-white bg-primary-600 hover:bg-primary-700 focus:ring-4 focus:outline-none focus:ring-primary-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center dark:bg-primary-600 dark:hover:bg-primary-700 dark:focus:ring-primary-800">
             Sign in
           </button>
-          <p class="text-sm text-center font-light text-gray-500 dark:text-gray-400">
-            Don’t have an account yet?<br />
-            <a routerLink="/register" class="font-medium text-primary-600 hover:underline dark:text-primary-500"
-              >Sign up</a
-            >
-          </p>
         </form>
       </div>
     </div>

--- a/frontend/cloud-ui/src/app/verify/verify.component.html
+++ b/frontend/cloud-ui/src/app/verify/verify.component.html
@@ -22,6 +22,14 @@
             class="py-2.5 px-5 me-2 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-lg border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-4 focus:ring-gray-100 dark:focus:ring-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-600 dark:hover:text-white dark:hover:bg-gray-700">
             Send again
           </button>
+          <p class="text-sm mt-5 text-center font-light text-gray-500 dark:text-gray-400">
+            Already verified?<br />
+            <button
+              (click)="logoutAndRedirectToLogin()"
+              class="font-medium text-primary-600 hover:underline dark:text-primary-500">
+              Back to Login
+            </button>
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/cloud-ui/src/app/verify/verify.component.ts
+++ b/frontend/cloud-ui/src/app/verify/verify.component.ts
@@ -1,15 +1,18 @@
 import {Component, inject} from '@angular/core';
 import {SettingsService} from '../services/settings.service';
-import {firstValueFrom, take, timeout, timer} from 'rxjs';
+import {firstValueFrom} from 'rxjs';
 import {ToastService} from '../services/toast.service';
+import {AuthService} from '../services/auth.service';
 
 @Component({
   selector: 'app-verify',
   templateUrl: './verify.component.html',
+  imports: [],
 })
 export class VerifyComponent {
   private readonly settings = inject(SettingsService);
   private readonly toast = inject(ToastService);
+  private readonly auth = inject(AuthService);
   public requestMailEnabled = true;
 
   public async requestMail() {
@@ -20,5 +23,10 @@ export class VerifyComponent {
     } catch (e) {
       this.requestMailEnabled = true;
     }
+  }
+
+  public async logoutAndRedirectToLogin() {
+    await firstValueFrom(this.auth.logout());
+    location.assign('/login');
   }
 }


### PR DESCRIPTION
If a user verified its email in a different browser / device he is stuck on the verify page. Going back to the login page deletes the current token and allows to login again.

I also removed the register links as we mostly want to register users via the form.


_I got stuck multiple times on that step already_