### PR TITLE
chore: change agent secret encoding from base64 to hex

### DIFF
--- a/internal/security/password.go
+++ b/internal/security/password.go
@@ -3,7 +3,7 @@ package security
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/base64"
+	"encoding/hex"
 	"errors"
 
 	"github.com/glasskube/cloud/internal/types"
@@ -68,6 +68,9 @@ func generateSalt() ([]byte, error) {
 
 func GenerateAccessKey() (string, error) {
 	key := make([]byte, 16)
-	_, err := rand.Read(key)
-	return base64.URLEncoding.EncodeToString(key), err
+	if _, err := rand.Read(key); err != nil {
+		return "", err
+	} else {
+		return hex.EncodeToString(key), nil
+	}
 }


### PR DESCRIPTION
this is actually **not** a breaking change, because we hash the already encoded secret