### PR TITLE
fix(backend): avoid struct parsing error after update statement

### DIFF
--- a/internal/db/deployment_targets.go
+++ b/internal/db/deployment_targets.go
@@ -235,7 +235,7 @@ func UpdateDeploymentTargetAccess(ctx context.Context, dt *types.DeploymentTarge
 
 func UpdateDeploymentTargetReportedAgentVersionID(
 	ctx context.Context,
-	dt *types.DeploymentTarget,
+	dt *types.DeploymentTargetWithCreatedBy,
 	agentVersionID string,
 ) error {
 	db := internalctx.GetDb(ctx)
@@ -253,7 +253,7 @@ func UpdateDeploymentTargetReportedAgentVersionID(
 	if err != nil {
 		return err
 	} else if updated, err := pgx.CollectExactlyOneRow(rows,
-		pgx.RowToAddrOfStructByName[types.DeploymentTarget]); err != nil {
+		pgx.RowToAddrOfStructByName[types.DeploymentTargetWithCreatedBy]); err != nil {
 		return err
 	} else {
 		*dt = *updated

--- a/internal/handlers/agent.go
+++ b/internal/handlers/agent.go
@@ -311,7 +311,7 @@ func agentAuthDeploymentTargetCtxMiddleware(next http.Handler) http.Handler {
 				} else if deploymentTarget.ReportedAgentVersionID == nil ||
 					reportedVersion.ID != *deploymentTarget.ReportedAgentVersionID {
 					if err := db.UpdateDeploymentTargetReportedAgentVersionID(
-						ctx, &deploymentTarget.DeploymentTarget, reportedVersion.ID); err != nil {
+						ctx, deploymentTarget, reportedVersion.ID); err != nil {
 						log.Error("could not update reported agent version", zap.Error(err))
 						sentry.GetHubFromContext(ctx).CaptureException(err)
 					}


### PR DESCRIPTION
fixes this sentry issue: https://glasskube.sentry.io/issues/17603443/events/2b55350bd55646c8a42b8f48a8f383a4/

struct doesn't have corresponding row field created_by @ https://github.com/glasskube/distr/blob/6bde5600ac8c3bd8ee8f52b8a613175b5b4025e8/internal/handlers/agent.go#L316