### PR TITLE
fix(ui): update deployment targets list immediately

### DIFF
--- a/frontend/ui/src/app/components/installation-wizard/installation-wizard.component.ts
+++ b/frontend/ui/src/app/components/installation-wizard/installation-wizard.component.ts
@@ -11,7 +11,7 @@ import {modalFlyInOut} from '../../animations/modal';
 import {ConnectInstructionsComponent} from '../connect-instructions/connect-instructions.component';
 import {ApplicationsService} from '../../services/applications.service';
 import {DeploymentTargetsService} from '../../services/deployment-targets.service';
-import {DeploymentService} from '../../services/deployment.service';
+import {DeploymentStatusService} from '../../services/deployment-status.service';
 import {ToastService} from '../../services/toast.service';
 import {YamlEditorComponent} from '../yaml-editor.component';
 import {InstallationWizardStepperComponent} from './installation-wizard-stepper.component';
@@ -46,7 +46,6 @@ export class InstallationWizardComponent implements OnInit, OnDestroy {
   private readonly toast = inject(ToastService);
   private readonly applications = inject(ApplicationsService);
   private readonly deploymentTargets = inject(DeploymentTargetsService);
-  private readonly deployments = inject(DeploymentService);
 
   @ViewChild('stepper') private stepper?: CdkStepper;
 
@@ -224,7 +223,7 @@ export class InstallationWizardComponent implements OnInit, OnDestroy {
       } else {
         deployment.envFileData = undefined;
       }
-      await firstValueFrom(this.deployments.createOrUpdate(deployment as DeploymentRequest));
+      await firstValueFrom(this.deploymentTargets.deploy(deployment as DeploymentRequest));
       this.toast.success('Deployment saved successfully');
       this.close();
     } catch (e) {

--- a/frontend/ui/src/app/components/onboarding-wizard/onboarding-wizard.component.ts
+++ b/frontend/ui/src/app/components/onboarding-wizard/onboarding-wizard.component.ts
@@ -8,7 +8,7 @@ import {disableControlsWithoutEvent, enableControlsWithoutEvent} from '../../../
 import {modalFlyInOut} from '../../animations/modal';
 import {ApplicationsService} from '../../services/applications.service';
 import {DeploymentTargetsService} from '../../services/deployment-targets.service';
-import {DeploymentService} from '../../services/deployment.service';
+import {DeploymentStatusService} from '../../services/deployment-status.service';
 import {CreateUserAccountRequest, UsersService} from '../../services/users.service';
 import {ConnectInstructionsComponent} from '../connect-instructions/connect-instructions.component';
 import {OnboardingWizardIntroComponent} from './intro/onboarding-wizard-intro.component';
@@ -48,7 +48,6 @@ export class OnboardingWizardComponent implements OnInit, OnDestroy {
 
   private readonly applications = inject(ApplicationsService);
   private readonly deploymentTargets = inject(DeploymentTargetsService);
-  private readonly deployments = inject(DeploymentService);
   private readonly users = inject(UsersService);
   private readonly toast = inject(ToastService);
 
@@ -287,7 +286,7 @@ export class OnboardingWizardComponent implements OnInit, OnDestroy {
           this.createdDeploymentTarget = await firstValueFrom(
             this.deploymentTargets.create(this.getDeploymentTargetForSubmit())
           );
-          await firstValueFrom(this.deployments.createOrUpdate(this.getDeploymentForSubmit()));
+          await firstValueFrom(this.deploymentTargets.deploy(this.getDeploymentForSubmit()));
           this.nextStep();
         } else {
           await firstValueFrom(this.users.addUser(this.getUserAccountForSubmit()));

--- a/frontend/ui/src/app/deployments/deployment-targets.component.ts
+++ b/frontend/ui/src/app/deployments/deployment-targets.component.ts
@@ -33,7 +33,6 @@ import {
   firstValueFrom,
   lastValueFrom,
   map,
-  merge,
   Observable,
   of,
   Subject,
@@ -148,11 +147,7 @@ export class DeploymentTargetsComponent implements OnInit, AfterViewInit, OnDest
   });
 
   deployFormLoading = false;
-  private readonly refresh = new Subject<void>();
-  readonly deploymentTargets$ = merge(
-    this.deploymentTargets.poll(),
-    this.refresh.pipe(switchMap(() => this.deploymentTargets.list()))
-  );
+  readonly deploymentTargets$ = this.deploymentTargets.poll();
 
   readonly filteredDeploymentTargets$ = filteredByFormControl(
     this.deploymentTargets$,

--- a/frontend/ui/src/app/deployments/deployment-targets.component.ts
+++ b/frontend/ui/src/app/deployments/deployment-targets.component.ts
@@ -98,7 +98,7 @@ export class DeploymentTargetsComponent implements OnInit, AfterViewInit, OnDest
   private readonly overlay = inject(OverlayService);
   private readonly applications = inject(ApplicationsService);
   private readonly deploymentTargets = inject(DeploymentTargetsService);
-  private readonly deployments = inject(DeploymentStatusService);
+  private readonly deploymentStatuses = inject(DeploymentStatusService);
   private readonly agentVersions = inject(AgentVersionService);
 
   readonly magnifyingGlassIcon = faMagnifyingGlass;
@@ -399,7 +399,7 @@ export class DeploymentTargetsComponent implements OnInit, AfterViewInit, OnDest
     const deployment = deploymentTarget.deployment;
     if (deployment?.id) {
       this.selectedDeploymentTarget.set(deploymentTarget);
-      this.statuses = this.deployments.pollStatuses(deployment);
+      this.statuses = this.deploymentStatuses.pollStatuses(deployment);
       this.showModal(modal);
     }
   }

--- a/frontend/ui/src/app/services/deployment-status.service.ts
+++ b/frontend/ui/src/app/services/deployment-status.service.ts
@@ -6,13 +6,9 @@ import {Deployment, DeploymentRequest, DeploymentRevisionStatus} from '@glasskub
 @Injectable({
   providedIn: 'root',
 })
-export class DeploymentService {
+export class DeploymentStatusService {
   private readonly baseUrl = '/api/v1/deployments';
   private readonly httpClient = inject(HttpClient);
-
-  createOrUpdate(request: DeploymentRequest): Observable<Deployment> {
-    return this.httpClient.put<Deployment>(this.baseUrl, request);
-  }
 
   getStatuses(depl: Deployment): Observable<DeploymentRevisionStatus[]> {
     return this.httpClient.get<DeploymentRevisionStatus[]>(`${this.baseUrl}/${depl.id}/status`);


### PR DESCRIPTION
I moved `deploy` over to `DeploymentTargetsService`, because of the shared data they seem to be more related to each other. 

Also at this point the cache in the `DeploymentTargetsService` is almost meaningless because we refetch on every change anyway. 

