### PR TITLE
ci: only build multiplatform images on tag

### DIFF
--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Docker build (push only for tag)
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           file: Dockerfile.${{ matrix.agent }}
           build-args: |
             COMMIT=${{ steps.generate.outputs.sha_short }}

--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Docker build (push on tag only)
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           context: .
           file: Dockerfile.hub
           push: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
This will improve build performance on PRs and hopefully prevent timeouts like here: https://github.com/glasskube/distr/actions/runs/13234525331/job/36936976899