### PR TITLE
fix(backend): improve graceful shutdown procedure

### DIFF
--- a/cmd/hub/main.go
+++ b/cmd/hub/main.go
@@ -55,6 +55,7 @@ func main() {
 	})
 
 	util.Must(server.Start(":8080"))
+	server.WaitForShutdown()
 }
 
 func onSigterm(callback func()) {


### PR DESCRIPTION
From the `http.Server` [documentation](https://pkg.go.dev/net/http#Server.Shutdown):

> When Shutdown is called, [Serve](https://pkg.go.dev/net/http#Serve), [ListenAndServe](https://pkg.go.dev/net/http#ListenAndServe), and [ListenAndServeTLS](https://pkg.go.dev/net/http#ListenAndServeTLS) immediately return [ErrServerClosed](https://pkg.go.dev/net/http#ErrServerClosed). Make sure the program doesn't exit and waits instead for Shutdown to return.

Previously we didn't do that. `ListenAndServe` exits and we immediately proceed with shutting down the DB pool and exiting. 