### PR TITLE
ci: increase "Build Agents" timeout to 30 minutes

### DIFF
--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-agent:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
This should help with tag builds failing, like: https://github.com/glasskube/distr/actions/runs/13628901130