### PR TITLE
fix(agent): kubernetes agent GetLatestHelmRelease supports more than 10 revisions

### DIFF
--- a/cmd/agent/kubernetes/helm_actions.go
+++ b/cmd/agent/kubernetes/helm_actions.go
@@ -68,12 +68,8 @@ func GetLatestHelmRelease(
 	if err != nil {
 		return nil, err
 	}
-	historyAction := action.NewHistory(cfg)
-	if releases, err := historyAction.Run(deployment.ReleaseName); err != nil {
-		return nil, err
-	} else {
-		return releases[len(releases)-1], nil
-	}
+	// Get returns the latest revision by default
+	return action.NewGet(cfg).Run(deployment.ReleaseName)
 }
 
 func RunHelmPreflight(


### PR DESCRIPTION
Currently the agent refuses to make further changes after 10 revisions because the releases returned by the history action are sorted alphabetically by name, so v10 comes before v9 .....