### PR TITLE
chore(agent): rename cluster role binding

### DIFF
--- a/internal/resources/embedded/agent/kubernetes/v1/manifest.yaml.tmpl
+++ b/internal/resources/embedded/agent/kubernetes/v1/manifest.yaml.tmpl
@@ -76,7 +76,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: distr-agent
+  name: distr-agent-{{ .targetNamespace }}
 subjects:
   - kind: ServiceAccount
     name: distr-agent


### PR DESCRIPTION
This allows multiple cluster scoped agents per cluster