### PR TITLE
fix(security): add workflow read permission to validate migrations job

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -14,6 +14,8 @@ jobs:
   validate-migrations:
     name: Validate migrations
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: hack/validate-migrations.sh


### PR DESCRIPTION
Potential fix for [https://github.com/glasskube/distr/security/code-scanning/14](https://github.com/glasskube/distr/security/code-scanning/14)

To fix the issue, add a `permissions` block to the `validate-migrations` job. Since the job does not appear to require write access or any specific permissions, the minimal permissions block should set `contents: read`. This limits the `GITHUB_TOKEN` to read-only access to repository contents, adhering to the principle of least privilege.

Changes should be made to the `.github/workflows/build-hub.yaml` file, specifically within the `validate-migrations` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
