### PR TITLE
ci: build agent in native runners

### DIFF
--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build-agent:
+    if: ${{ matrix.platform.enabled }}
     timeout-minutes: 30
     runs-on: ${{ matrix.platform.runner }}
     permissions:
@@ -25,8 +26,10 @@ jobs:
         platform:
           - arch: linux/amd64
             runner: ubuntu-latest
+            enabled: true
           - arch: linux/arm64
             runner: ubuntu-24.04-arm
+            enabled: ${{ startsWith(github.ref, 'refs/tags/') }}
     env:
       REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
     steps:

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -5,9 +5,9 @@ name: Build Agents
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     tags:
-      - "*"
+      - '*'
   pull_request:
 
 jobs:

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -75,7 +75,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ matrix.agent }}-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -97,7 +97,7 @@ jobs:
           - kubernetes-agent
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-${{ matrix.agent }}-*
@@ -128,13 +128,15 @@ jobs:
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
-      - name: Inspect image
+      - name: Get digest of the created image
+        id: digest
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          DIGEST=$(docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }} --format "{{ print .Manifest.Digest }}")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
       - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
       - name: Sign the images with GitHub OIDC Token
         env:
-          DIGEST: ${{ steps.build-push.outputs.digest }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           images=""

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -5,9 +5,9 @@ name: Build Agents
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     tags:
-      - "*"
+      - '*'
   pull_request:
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
           - arch: linux/arm64
             runner: ubuntu-24.04-arm
     env:
-      REGISTRY_IMAGE: ghcr.io/glasskube/distr-develop/${{ matrix.agent }}
+      REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,6 +36,7 @@ jobs:
         id: generate
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login to GitHub Container Registry
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
@@ -59,7 +60,7 @@ jobs:
             VERSION=${{ github.ref_name }}
           tags: ${{ env.REGISTRY_IMAGE }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ startsWith(github.ref, 'refs/tags/') }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           sbom: true
@@ -82,6 +83,7 @@ jobs:
           retention-days: 1
 
   merge:
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs:
       - build-agent
@@ -95,7 +97,7 @@ jobs:
           - docker-agent
           - kubernetes-agent
     env:
-      REGISTRY_IMAGE: ghcr.io/glasskube/distr-develop/${{ matrix.agent }}
+      REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   build-agent:
-    if: ${{ matrix.platform.enabled }}
     timeout-minutes: 30
     runs-on: ${{ matrix.platform.runner }}
     permissions:
@@ -26,10 +25,8 @@ jobs:
         platform:
           - arch: linux/amd64
             runner: ubuntu-latest
-            enabled: true
           - arch: linux/arm64
             runner: ubuntu-24.04-arm
-            enabled: ${{ startsWith(github.ref, 'refs/tags/') }}
     env:
       REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
     steps:

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -87,6 +87,7 @@ jobs:
       - build-agent
     permissions:
       contents: read
+      id-token: write
       packages: write
     strategy:
       matrix:

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-agent:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
@@ -22,6 +22,13 @@ jobs:
         agent:
           - docker-agent
           - kubernetes-agent
+        platform:
+          - arch: linux/amd64
+            runner: ubuntu-latest
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+    env:
+      REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -41,7 +48,70 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ghcr.io/glasskube/distr/${{ matrix.agent }}
+          images: ${{ env.REGISTRY_IMAGE }}
+      - name: Docker build (push only for tag)
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          platforms: ${{ matrix.platform.arch }}
+          file: Dockerfile.${{ matrix.agent }}
+          build-args: |
+            COMMIT=${{ steps.generate.outputs.sha_short }}
+            VERSION=${{ github.ref_name }}
+          tags: ${{ env.REGISTRY_IMAGE }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Prepare for export
+        run: |
+          platform=${{ matrix.platform.arch }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.agent }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs:
+      - build-agent
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        agent:
+          - docker-agent
+          - kubernetes-agent
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.agent }}-*
+          merge-multiple: true
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=ref,event=branch
             type=sha,event=branch
@@ -51,16 +121,11 @@ jobs:
           labels: |
             org.opencontainers.image.description=Distr agent software
             org.opencontainers.image.vendor=Glasskube
-      - name: Docker build (push only for tag)
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          file: Dockerfile.${{ matrix.agent }}
-          build-args: |
-            COMMIT=${{ steps.generate.outputs.sha_short }}
-            VERSION=${{ github.ref_name }}
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -5,9 +5,9 @@ name: Build Agents
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     tags:
-      - '*'
+      - "*"
   pull_request:
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
           - arch: linux/arm64
             runner: ubuntu-24.04-arm
     env:
-      REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
+      REGISTRY_IMAGE: ghcr.io/glasskube/distr-develop/${{ matrix.agent }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -36,7 +36,6 @@ jobs:
         id: generate
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Login to GitHub Container Registry
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
@@ -60,7 +59,7 @@ jobs:
             VERSION=${{ github.ref_name }}
           tags: ${{ env.REGISTRY_IMAGE }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,push-by-digest=true,name-canonical=true,push=${{ startsWith(github.ref, 'refs/tags/') }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           sbom: true
@@ -83,7 +82,6 @@ jobs:
           retention-days: 1
 
   merge:
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs:
       - build-agent
@@ -96,7 +94,7 @@ jobs:
           - docker-agent
           - kubernetes-agent
     env:
-      REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
+      REGISTRY_IMAGE: ghcr.io/glasskube/distr-develop/${{ matrix.agent }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/build-agent.yaml
+++ b/.github/workflows/build-agent.yaml
@@ -95,6 +95,8 @@ jobs:
         agent:
           - docker-agent
           - kubernetes-agent
+    env:
+      REGISTRY_IMAGE: ghcr.io/glasskube/distr/${{ matrix.agent }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0


### PR DESCRIPTION
Test images created with this workflow can be seen at:
* https://github.com/glasskube/distr/pkgs/container/distr-develop%2Fdocker-agent
* https://github.com/glasskube/distr/pkgs/container/distr-develop%2Fkubernetes-agent

Checking the SBOM:
```
docker buildx imagetools inspect ghcr.io/glasskube/distr-develop/kubernetes-agent:sha-8fe81d6 --format '{{ json (index .SBOM "linux/amd64").SPDX }}'
```
(the "list" manifest doesn't have an SBOM, because the SBOM is specific to each architecture, see [docs](https://docs.docker.com/build/metadata/attestations/sbom/#inspecting-sboms))

Checking the cosign signature: 
```
cosign verify ghcr.io/glasskube/distr-develop/docker-agent:sha-18a9a81 --certificate-identity https://github.com/glasskube/distr/.github/workflows/build-agent.yaml@refs/pull/1119/merge --certificate-oidc-issuer https://token.actions.githubusercontent.com
```