### PR TITLE
ci: fix image signing error on distr registry

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -139,7 +139,6 @@ jobs:
             registry.distr.sh/glasskube/distr
           tags: |
             type=ref,event=branch
-            type=sha,event=branch
             type=semver,pattern={{version}}
           flavor: |
             latest=false


### PR DESCRIPTION
When signing two tags referencing the same digest on the same registry, cosign first pushes one signature to the registry and then the other (or something like that). This means that the signature tag gets overwritten, which is not supported by the distr registry. By only pushing one tag (which was the intended behavior all along anyways), we should be able to mitigate this issue.

Happened here:
https://github.com/glasskube/distr/actions/runs/16049485666/job/45288489546