### PR TITLE
fix(ui): align theme icon with it's parent box

### DIFF
--- a/frontend/ui/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
+++ b/frontend/ui/src/app/components/color-scheme-switcher/color-scheme-switcher.component.html
@@ -8,12 +8,12 @@
     id="theme-toggle-dark-icon"
     [icon]="faMoon"
     size="lg"
-    class="w-4 h-4 mb-1 ml-1 text-gray-400 transition duration-75 dark:text-gray-400"></fa-icon>
+    class="w-4 h-4 mb-1 mr-1 text-gray-400 transition duration-75 dark:text-gray-400"></fa-icon>
   <fa-icon
     *ngIf="colorSchemeSignal() === 'dark'"
     id="theme-toggle-light-icon"
     [icon]="faSun"
     size="lg"
-    class="w-4 h-4 mb-1 text-gray-400 transition duration-75 dark:text-gray-400"></fa-icon>
+    class="w-4 h-4 mb-1 mr-1 text-gray-400 transition duration-75 dark:text-gray-400"></fa-icon>
   <span class="sr-only">Toggle dark mode</span>
 </button>


### PR DESCRIPTION
In this pr, i fixed alignment of theme icons(FaSun & FaMoon) with it's parent box

## Screenshot
### Before
<img width="68" height="66" alt="Screenshot from 2025-10-31 17-04-21" src="https://github.com/user-attachments/assets/505298e9-bacf-4dc4-b0ba-f950fba597ee" />

### After
<img width="66" height="62" alt="Screenshot from 2025-10-31 17-16-07" src="https://github.com/user-attachments/assets/3de2b8a6-b6b0-4760-9244-c361d6e93d01" />
