### PR TITLE
build: switch to mise for build task definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ You can then start the necessary containers and the Distr Hub with:
 # Start the database and a mock SMTP server
 docker compose up -d
 # Start Distr Hub
-make run
+mise watch serve -r
 ```
 
 Open your browser and navigate to [`http://localhost:8080/register`](http://localhost:8080/register) to register a user

--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,7 @@ run = 'npm run build:dev'
 sources = ["node_modules/**/*", "frontend/ui/**/*"]
 outputs = ["internal/frontend/dist/ui/"]
 
+# mise watch serve -r
 [tasks.serve]
 run = 'go run -ldflags="{{vars.ldflags}}" ./cmd/hub/ serve'
 depends = ["frontend-dev"]


### PR DESCRIPTION
The `serve` task has defined sources, so that it works with `mise watch serve -r`.