### PR TITLE
build: change version to not include edition

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -99,14 +99,15 @@ jobs:
           rm internal/frontend/dist/ui/browser/*.map || exit 1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          VERSION: ${{ github.ref_name }}${{ matrix.edition.suffix }}
+          VERSION: ${{ github.ref_name }}
+          SENTRY_VERSION: ${{ github.ref_name }}${{ matrix.edition.suffix }}
 
       - name: Build application
         run: go build -ldflags="$LDFLAGS" -o dist/distr ./cmd/hub/
         env:
           CGO_ENABLED: '0'
           LDFLAGS: >-
-            -X github.com/glasskube/distr/internal/buildconfig.version=${{ github.ref_name }}${{ matrix.edition.suffix }}
+            -X github.com/glasskube/distr/internal/buildconfig.version=${{ github.ref_name }}
             -X github.com/glasskube/distr/internal/buildconfig.commit=${{ steps.hash.outputs.sha_short }}
             -X github.com/glasskube/distr/internal/buildconfig.edition=${{ matrix.edition.name }}
 

--- a/frontend/ui/src/app/components/side-bar/side-bar.component.html
+++ b/frontend/ui/src/app/components/side-bar/side-bar.component.html
@@ -392,10 +392,15 @@
       </div>
     }
 
-    <div class="text-center text-xs text-gray-300 dark:text-gray-600">
-      {{ buildConfig.version }}
-      (<code>{{ buildConfig.commit }}</code
-      >)
+    <div class="flex flex-col items-center text-xs">
+      @if (edition === 'community') {
+        <div class="text-gray-500 dark:text-gray-400">Community Edition</div>
+      }
+      <div class="text-gray-300 dark:text-gray-600">
+        {{ buildConfig.version }}
+        (<code>{{ buildConfig.commit }}</code
+        >)
+      </div>
     </div>
   </div>
 </aside>

--- a/frontend/ui/src/app/components/side-bar/side-bar.component.ts
+++ b/frontend/ui/src/app/components/side-bar/side-bar.component.ts
@@ -21,6 +21,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import {map} from 'rxjs';
 import {buildConfig} from '../../../buildconfig';
+import {environment} from '../../../env/env';
 import {RequireCustomerDirective, RequireVendorDirective} from '../../directives/required-role.directive';
 import {AuthService} from '../../services/auth.service';
 import {FeatureFlagService} from '../../services/feature-flag.service';
@@ -52,6 +53,7 @@ export class SideBarComponent {
   private readonly organizationService = inject(OrganizationService);
 
   protected readonly buildConfig = buildConfig;
+  protected readonly edition = environment.edition;
 
   protected readonly faDashboard = faDashboard;
   protected readonly faBoxesStacked = faBoxesStacked;

--- a/frontend/ui/src/main.ts
+++ b/frontend/ui/src/main.ts
@@ -21,7 +21,7 @@ bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err))
   if (remoteEnvironment.sentryDsn) {
     Sentry.init({
       enabled: environment.production,
-      release: buildConfig.version ?? buildConfig.commit,
+      release: buildConfig.sentryVersion ?? buildConfig.commit,
       dsn: remoteEnvironment.sentryDsn,
       environment: remoteEnvironment.sentryEnvironment,
       integrations: [Sentry.browserTracingIntegration()],

--- a/hack/current-commit.sh
+++ b/hack/current-commit.sh
@@ -1,0 +1,1 @@
+export COMMIT=$(git rev-parse --short HEAD)

--- a/hack/sentry-release.sh
+++ b/hack/sentry-release.sh
@@ -5,15 +5,15 @@ if [ -z "$SENTRY_AUTH_TOKEN" ]; then
   exit 1
 fi
 
-if [ -z "$VERSION" ]; then
-  echo "VERSION is not set"
+if [ -z "$SENTRY_VERSION" ]; then
+  echo "SENTRY_VERSION is not set"
   exit 1
 fi
 
 export SENTRY_ORG="glasskube"
 export SENTRY_PROJECT="distr-frontend"
 
-npx sentry-cli releases new "$VERSION"
-npx sentry-cli releases set-commits "$VERSION" --auto
-npx sentry-cli sourcemaps upload --release="$VERSION" internal/frontend/dist/ui/browser
-npx sentry-cli releases finalize "$VERSION"
+npx sentry-cli releases new "$SENTRY_VERSION"
+npx sentry-cli releases set-commits "$SENTRY_VERSION" --auto
+npx sentry-cli sourcemaps upload --release="$SENTRY_VERSION" internal/frontend/dist/ui/browser
+npx sentry-cli releases finalize "$SENTRY_VERSION"

--- a/hack/update-frontend-version.js
+++ b/hack/update-frontend-version.js
@@ -12,12 +12,14 @@ if (!version) {
   }
 }
 
+let sentryVersion = env['SENTRY_VERSION'] || version;
+
 let commit = env['COMMIT'];
 if (!commit) {
   commit = execSync('git rev-parse --short HEAD').toString().trim();
 }
 
-const buildconfig = {version, commit, release: version !== 'snapshot'};
+const buildconfig = {version, sentryVersion, commit, release: version !== 'snapshot'};
 
 console.log(buildconfig);
 

--- a/internal/buildconfig/edition.go
+++ b/internal/buildconfig/edition.go
@@ -7,6 +7,10 @@ const (
 
 var edition = EnterpriseEdition
 
+func Edition() string {
+	return edition
+}
+
 func IsCommunityEdition() bool {
 	return edition == CommunityEdition
 }

--- a/internal/svc/registry.go
+++ b/internal/svc/registry.go
@@ -51,6 +51,7 @@ func newRegistry(ctx context.Context, reg *Registry) (*Registry, error) {
 	reg.logger.Info("initializing service registry",
 		zap.String("version", buildconfig.Version()),
 		zap.String("commit", buildconfig.Commit()),
+		zap.String("edition", buildconfig.Edition()),
 		zap.Bool("release", buildconfig.IsRelease()))
 
 	if tracers, err := reg.createTracer(ctx); err != nil {

--- a/mise.toml
+++ b/mise.toml
@@ -8,9 +8,9 @@ pnpm = "10.24.0"
 stripe = "1.33.0"
 
 [env]
+_.source = ['hack/current-commit.sh']
 DISTR_ENV = '.env.development.local'
-VERSION = "snapshot"
-COMMIT = "TODO"
+VERSION = 'snapshot'
 CGO_ENABLED = "0"
 
 [vars]


### PR DESCRIPTION
This change removes the edition suffix (-ce/-ee) from the version string in both the frontend and backend. It was originally included because Sentry requires different version names for the two built artifacts, so I added a separate SENTRY_VERSION environment variable for the frontend that does include the suffix. The edition is now shown separately in the backend and frontend which makes more sense anyways, IMO.