### PR TITLE
ci: switch to npm trusted publishing for sdk/js

### DIFF
--- a/.github/workflows/build-sdk.yaml
+++ b/.github/workflows/build-sdk.yaml
@@ -19,6 +19,7 @@ jobs:
         working-directory: ./sdk/js
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -53,5 +54,3 @@ jobs:
       - name: Publish to npmjs
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}


### PR DESCRIPTION
With npmjs.org rolling out hardening changes to their access token policies, it is now recommended to use trusted publishing in CI environments. The OIDC connection on npmjs.org is alread set up according to https://docs.npmjs.com/trusted-publishers.

Similar example:
https://github.com/nodejs/nodejs.org/blob/76b456f8afe02c9abc0827fe1e78a08546d9b56f/.github/workflows/publish-packages.yml

I don't *think* there is anything major we need to change, but there seem to have been some problems for other people in the past: https://github.com/pnpm/pnpm/issues/9812