### PR TITLE
fix(ui): disable @angular/cdk overlay using popover API

### DIFF
--- a/frontend/ui/src/app/app.config.ts
+++ b/frontend/ui/src/app/app.config.ts
@@ -1,3 +1,4 @@
+import {OVERLAY_DEFAULT_CONFIG} from '@angular/cdk/overlay';
 import {provideHttpClient, withInterceptors} from '@angular/common/http';
 import {
   ApplicationConfig,
@@ -34,5 +35,6 @@ export const appConfig: ApplicationConfig = {
       },
     }),
     provideAppInitializer(async () => inject(Sentry.TraceService)),
+    {provide: OVERLAY_DEFAULT_CONFIG, useValue: {usePopover: false}},
   ],
 };


### PR DESCRIPTION
This is unfortunate, but necessary because ngx-toastr does not use the same API, so toasts will always appear behind other overlays.

Related: https://github.com/scttcper/ngx-toastr/issues/1042