### PR TITLE
fix: prevent template errors for mailsending

### DIFF
--- a/internal/mailsending/verify.go
+++ b/internal/mailsending/verify.go
@@ -2,9 +2,13 @@ package mailsending
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/distr-sh/distr/internal/apierrors"
 	"github.com/distr-sh/distr/internal/authjwt"
 	internalctx "github.com/distr-sh/distr/internal/context"
+	"github.com/distr-sh/distr/internal/db"
 	"github.com/distr-sh/distr/internal/mail"
 	"github.com/distr-sh/distr/internal/mailtemplates"
 	"github.com/distr-sh/distr/internal/types"
@@ -15,6 +19,13 @@ func SendUserVerificationMail(ctx context.Context, userAccount types.UserAccount
 	mailer := internalctx.GetMailer(ctx)
 	log := internalctx.GetLogger(ctx)
 
+	branding, err := db.GetOrganizationBranding(ctx, org.ID)
+	if err != nil && !errors.Is(err, apierrors.ErrNotFound) {
+		return fmt.Errorf("failed to get organization branding for verification mail: %w", err)
+	}
+
+	owb := types.OrganizationWithBranding{Organization: org, Branding: branding}
+
 	// TODO: Should probably use a different mechanism for invite tokens but for now this should work OK
 	if _, token, err := authjwt.GenerateVerificationTokenValidFor(userAccount); err != nil {
 		log.Error("could not generate verification token for email verification", zap.Error(err))
@@ -23,7 +34,7 @@ func SendUserVerificationMail(ctx context.Context, userAccount types.UserAccount
 		mail := mail.New(
 			mail.To(userAccount.Email),
 			mail.Subject("Verify your Distr account"),
-			mail.HtmlBodyTemplate(mailtemplates.VerifyEmail(userAccount, org, token)),
+			mail.HtmlBodyTemplate(mailtemplates.VerifyEmail(userAccount, owb, token)),
 		)
 		if err := mailer.Send(ctx, mail); err != nil {
 			log.Error(

--- a/internal/mailtemplates/templates.go
+++ b/internal/mailtemplates/templates.go
@@ -70,11 +70,15 @@ func InviteUser(
 		}
 }
 
-func VerifyEmail(userAccount types.UserAccount, org types.Organization, token string) (*template.Template, any) {
+func VerifyEmail(
+	userAccount types.UserAccount,
+	org types.OrganizationWithBranding,
+	token string,
+) (*template.Template, any) {
 	return templates.Lookup("verify-email-registration.html"), map[string]any{
 		"UserAccount":  userAccount,
 		"Organization": org,
-		"Host":         customdomains.AppDomainOrDefault(org),
+		"Host":         customdomains.AppDomainOrDefault(org.Organization),
 		"Token":        token,
 	}
 }
@@ -96,11 +100,15 @@ func PasswordReset(
 	}
 }
 
-func UpdateEmail(userAccount types.UserAccount, org types.Organization, token string) (*template.Template, any) {
+func UpdateEmail(
+	userAccount types.UserAccount,
+	org types.OrganizationWithBranding,
+	token string,
+) (*template.Template, any) {
 	return templates.Lookup("update-email.html"), map[string]any{
 		"UserAccount":  userAccount,
 		"Organization": org,
-		"Host":         customdomains.AppDomainOrDefault(org),
+		"Host":         customdomains.AppDomainOrDefault(org.Organization),
 		"Token":        token,
 	}
 }


### PR DESCRIPTION
Currently we get the following error:
> template: logo.html:1:37: executing \"fragments/logo.html\" at <.Organization.Branding>: can't evaluate field Branding in type interface {}