### PR TITLE
fix(ui): update user name without profile image

### DIFF
--- a/frontend/ui/src/app/user-settings/user-settings.component.ts
+++ b/frontend/ui/src/app/user-settings/user-settings.component.ts
@@ -112,7 +112,7 @@ export class UserSettingsComponent {
       const result = await firstValueFrom(
         this.settingsService.updateUserSettings({
           name: this.generalForm.value.name ?? undefined,
-          imageId: this.generalForm.value.imageId ?? undefined,
+          imageId: this.generalForm.value.imageId || undefined,
         })
       );
       this.toast.success('User settings saved successfully.');


### PR DESCRIPTION
The `imageId` form control is initialized to `''`, and when the user has no profile image, `patchValue` leaves it as `''`. The `??` operator only converts `null`/`undefined` to `undefined`, so the empty string `""` was being sent to the backend, which tried to parse it as a UUID — causing `invalid UUID length: 0`. Changing to `||` ensures empty strings also become `undefined` and are omitted from the request.