### PR TITLE
fix(chart): add imagePullSecrets to CronJob template

### DIFF
--- a/deploy/charts/distr/templates/cronjob.yaml
+++ b/deploy/charts/distr/templates/cronjob.yaml
@@ -28,6 +28,10 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
         spec:
+          {{- with $.Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           containers:
             - name: hub
               {{- with $job.args }}


### PR DESCRIPTION
## Summary

- Add `imagePullSecrets` to CronJob pod spec, matching the existing Deployment template

The CronJob template was missing `imagePullSecrets`, causing pods to fail with `ImagePullBackOff` when scheduled on nodes that don't have the image cached. The Deployment template already includes this block, but the CronJob template was missing it.

Fixes #1868

## Test plan

- [ ] Verify `helm template` output includes `imagePullSecrets` in CronJob pod specs when `imagePullSecrets` is set in values
- [ ] Deploy chart with `imagePullSecrets` configured and confirm CronJob pods can pull from private registries

🤖 Generated with [Claude Code](https://claude.com/claude-code)