### PR TITLE
ci(backend): use ephemeral public key if not building for tag

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -193,7 +193,12 @@ jobs:
       - name: Generate ephemeral license JWT (non-tag enterprise only)
         id: ephemeral-license
         if: ${{ matrix.edition.name == 'enterprise' && !startsWith(github.ref, 'refs/tags/') }}
-        run: echo "license-key=$(LICENSE_KEY_PRIVATE_KEY='${{ steps.ephemeral-key.outputs.private-key }}' dist/distr-amd64 license-key generate --no-save --payload='{"ld":{}}')" >> $GITHUB_OUTPUT
+        run: echo "license-key=$(dist/distr-amd64 license-key generate --no-save --payload='{"ld":{}}')" >> $GITHUB_OUTPUT
+        env:
+          LICENSE_KEY_PRIVATE_KEY: ${{ steps.ephemeral-key.outputs.private-key }}
+          DATABASE_URL: postgres://placeholder
+          JWT_SECRET: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+          DISTR_HOST: http://placeholder
 
       - name: Start Hub and verify migrations and docs
         shell: bash

--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -155,11 +155,17 @@ jobs:
         if: ${{ matrix.edition.name == 'enterprise' && startsWith(github.ref, 'refs/tags/') }}
         run: echo "${{ secrets.LICENSE_PUBLIC_KEY }}" > internal/license/embedded/pubkey.pem
 
-      - name: Generate ephemeral license public key (non-tag)
+      - name: Generate ephemeral license key (non-tag)
+        id: ephemeral-key
         if: ${{ matrix.edition.name == 'enterprise' && !startsWith(github.ref, 'refs/tags/') }}
         run: |
           openssl genpkey -algorithm ed25519 -out /tmp/ephemeral_private.pem
           openssl pkey -in /tmp/ephemeral_private.pem -pubout -out internal/license/embedded/pubkey.pem
+          {
+            echo "private-key<<EOF"
+            cat /tmp/ephemeral_private.pem
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Build application (amd64)
         run: go build -ldflags="$LDFLAGS" -o dist/distr-amd64 ./cmd/hub/
@@ -184,6 +190,11 @@ jobs:
             -X github.com/distr-sh/distr/internal/buildconfig.commit=${{ steps.hash.outputs.sha_short }}
             -X github.com/distr-sh/distr/internal/buildconfig.edition=${{ matrix.edition.name }}
 
+      - name: Generate ephemeral license JWT (non-tag enterprise only)
+        id: ephemeral-license
+        if: ${{ matrix.edition.name == 'enterprise' && !startsWith(github.ref, 'refs/tags/') }}
+        run: echo "license-key=$(LICENSE_KEY_PRIVATE_KEY='${{ steps.ephemeral-key.outputs.private-key }}' dist/distr-amd64 license generate --no-save --payload='{"ld":{}}')" >> $GITHUB_OUTPUT
+
       - name: Start Hub and verify migrations and docs
         shell: bash
         run: |
@@ -197,7 +208,7 @@ jobs:
           DATABASE_URL: postgres://test-user:test-password@localhost:5432/distr
           JWT_SECRET: H4V7z6mEpe8/k5H/KyogT/iATJhNpEIUMd5cHF6mqF8=
           DISTR_HOST: http://localhost:8080
-          LICENSE_KEY: ${{ matrix.edition.name == 'enterprise' && secrets.LICENSE_KEY || '' }}
+          LICENSE_KEY: ${{ matrix.edition.name == 'enterprise' && (startsWith(github.ref, 'refs/tags/') && secrets.LICENSE_KEY || steps.ephemeral-license.outputs.license-key) || '' }}
 
       - name: Generate SBOM for frontend project
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -151,9 +151,15 @@ jobs:
           VERSION: ${{ github.ref_name }}
           SENTRY_VERSION: ${{ github.ref_name }}${{ matrix.edition.suffix }}
 
-      - name: Write license public key
-        if: ${{ matrix.edition.name == 'enterprise' }}
+      - name: Write license public key (tag only)
+        if: ${{ matrix.edition.name == 'enterprise' && startsWith(github.ref, 'refs/tags/') }}
         run: echo "${{ secrets.LICENSE_PUBLIC_KEY }}" > internal/license/embedded/pubkey.pem
+
+      - name: Generate ephemeral license public key (non-tag)
+        if: ${{ matrix.edition.name == 'enterprise' && !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          openssl genpkey -algorithm ed25519 -out /tmp/ephemeral_private.pem
+          openssl pkey -in /tmp/ephemeral_private.pem -pubout -out internal/license/embedded/pubkey.pem
 
       - name: Build application (amd64)
         run: go build -ldflags="$LDFLAGS" -o dist/distr-amd64 ./cmd/hub/

--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: Generate ephemeral license JWT (non-tag enterprise only)
         id: ephemeral-license
         if: ${{ matrix.edition.name == 'enterprise' && !startsWith(github.ref, 'refs/tags/') }}
-        run: echo "license-key=$(LICENSE_KEY_PRIVATE_KEY='${{ steps.ephemeral-key.outputs.private-key }}' dist/distr-amd64 license generate --no-save --payload='{"ld":{}}')" >> $GITHUB_OUTPUT
+        run: echo "license-key=$(LICENSE_KEY_PRIVATE_KEY='${{ steps.ephemeral-key.outputs.private-key }}' dist/distr-amd64 license-key generate --no-save --payload='{"ld":{}}')" >> $GITHUB_OUTPUT
 
       - name: Start Hub and verify migrations and docs
         shell: bash

--- a/cmd/hub/cmd/license_generate.go
+++ b/cmd/hub/cmd/license_generate.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"os"
+	"fmt"
 	"time"
 
 	internalctx "github.com/distr-sh/distr/internal/context"
@@ -27,6 +27,7 @@ type GenerateLicenseKeyOptions struct {
 	NotBefore     string
 	ExpiresAt     string
 	ValidPeriod   string
+	NoSave        bool
 }
 
 func NewGenerateLicenseKeyCommand() *cobra.Command {
@@ -34,19 +35,15 @@ func NewGenerateLicenseKeyCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "generate",
 		PreRun: func(cmd *cobra.Command, args []string) { env.Initialize() },
-		Run: func(cmd *cobra.Command, args []string) {
-			if err := runGenerateLicenseKey(cmd.Context(), opts); err != nil {
-				os.Exit(1)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerateLicenseKey(cmd.Context(), opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.OrgID, "organization-id", "o", "", "Organization ID (required)")
-	util.Must(cmd.MarkFlagRequired("organization-id"))
-	cmd.Flags().StringVarP(&opts.CustomerOrgID, "customer-id", "c", "", "Customer organization ID (required)")
-	util.Must(cmd.MarkFlagRequired("customer-id"))
-	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "License key name (required)")
-	util.Must(cmd.MarkFlagRequired("name"))
+	cmd.Flags().StringVarP(&opts.OrgID, "organization-id", "o", "", "Organization ID (required without --no-save)")
+	cmd.Flags().StringVarP(&opts.CustomerOrgID, "customer-id", "c", "",
+		"Customer organization ID (required without --no-save)")
+	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "License key name (required without --no-save)")
 	cmd.Flags().StringVarP(&opts.Description, "description", "d", "", "License key description")
 	cmd.Flags().StringVarP(&opts.Payload, "payload", "p", "{}", "License key JSON payload")
 	cmd.Flags().StringVar(&opts.NotBefore, "not-before", "",
@@ -54,17 +51,70 @@ func NewGenerateLicenseKeyCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ExpiresAt, "expires-at", "",
 		"Date until the license key is valid (yyyy-mm-dd)")
 	cmd.Flags().StringVar(&opts.ValidPeriod, "valid-period", "8760h", "Validity period")
+	cmd.Flags().BoolVar(&opts.NoSave, "no-save", false, "Skip saving the license key to the database")
 	cmd.MarkFlagsMutuallyExclusive("expires-at", "valid-period")
+	cmd.MarkFlagsRequiredTogether("organization-id", "customer-id", "name")
+	for _, f := range []string{"organization-id", "customer-id", "name"} {
+		cmd.MarkFlagsOneRequired("no-save", f)
+		cmd.MarkFlagsMutuallyExclusive("no-save", f)
+	}
 
 	return cmd
 }
 
 func runGenerateLicenseKey(ctx context.Context, opts GenerateLicenseKeyOptions) error {
+	var notBefore time.Time
+	if opts.NotBefore != "" {
+		if t, err := time.Parse(time.DateOnly, opts.NotBefore); err != nil {
+			return fmt.Errorf("invalid not-before: %w", err)
+		} else {
+			notBefore = t
+		}
+	} else {
+		notBefore = time.Now()
+	}
+
+	var expiresAt time.Time
+	if opts.ExpiresAt != "" {
+		if t, err := time.Parse(time.DateOnly, opts.ExpiresAt); err != nil {
+			return fmt.Errorf("invalid expires-at: %w", err)
+		} else {
+			expiresAt = t
+		}
+	} else {
+		if d, err := time.ParseDuration(opts.ValidPeriod); err != nil {
+			return fmt.Errorf("invalid valid-period: %w", err)
+		} else {
+			expiresAt = notBefore.Add(d)
+		}
+	}
+
+	if opts.NoSave {
+		data := licensekey.LicenseKeyData{
+			LicenseKeyID: uuid.New(),
+			IssuedAt:     time.Now(),
+			NotBefore:    notBefore,
+			ExpiresAt:    expiresAt,
+			Payload:      json.RawMessage(opts.Payload),
+		}
+		token, err := licensekey.GenerateToken(data, env.Host())
+		if err != nil {
+			return fmt.Errorf("token creation error: %w", err)
+		}
+		fmt.Println(token)
+		return nil
+	}
+
 	registry := util.Require(svc.NewDefault(ctx))
 	defer func() { util.Must(registry.Shutdown(ctx)) }()
 	log := registry.GetLogger()
 
-	license := types.LicenseKey{Name: opts.Name, Payload: json.RawMessage(opts.Payload)}
+	license := types.LicenseKey{
+		Name:      opts.Name,
+		Payload:   json.RawMessage(opts.Payload),
+		NotBefore: &notBefore,
+		ExpiresAt: &expiresAt,
+	}
 
 	if opts.Description != "" {
 		license.Description = &opts.Description
@@ -82,35 +132,6 @@ func runGenerateLicenseKey(ctx context.Context, opts GenerateLicenseKeyOptions) 
 		return err
 	} else {
 		license.CustomerOrganizationID = &p
-	}
-
-	if opts.NotBefore != "" {
-		if t, err := time.Parse(time.DateOnly, opts.NotBefore); err != nil {
-			log.Error("invalid not-before", zap.Error(err))
-			return err
-		} else {
-			license.NotBefore = &t
-		}
-	} else {
-		t := time.Now()
-		license.NotBefore = &t
-	}
-
-	if opts.ExpiresAt != "" {
-		if t, err := time.Parse(time.DateOnly, opts.ExpiresAt); err != nil {
-			log.Error("invalid expires-at", zap.Error(err))
-			return err
-		} else {
-			license.ExpiresAt = &t
-		}
-	} else {
-		if d, err := time.ParseDuration(opts.ValidPeriod); err != nil {
-			log.Error("invalid valid-period", zap.Error(err))
-			return err
-		} else {
-			t := license.NotBefore.Add(d)
-			license.ExpiresAt = &t
-		}
 	}
 
 	log.Debug("creating license", zap.Any("license", license))


### PR DESCRIPTION
This should allow PRs from external contributors and bots to build cleanly again (e.g. #2275)