### PR TITLE
chore: replace Discord references with GitHub Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Distr is open-source software licensed under the [Apache 2.0 license](https://gi
 
 To avoid unnecessary and redundant work, please reach out before you start working on your contribution.
 
-You can either create an issue on GitHub or join our [Discord](https://discord.gg/6qqBSAWZfW) server to get in touch with the community.
+You can either create an issue on GitHub or join our [community forum](https://github.com/distr-sh/distr/discussions) to get in touch with the community.
 
 ## How to run distr for development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Distr enables software and AI companies to distribute applications to self-managed customers with minimal setup.
 
-### **[Website](https://distr.sh/?utm_source=github)** • **[Quickstart](https://distr.sh/docs/quickstart/?utm_source=github)** • **[Documentation](https://distr.sh/docs/?utm_source=github)** • **[Blog](https://distr.sh/blog/)** • **[Discord](https://discord.gg/6qqBSAWZfW)**
+### **[Website](https://distr.sh/?utm_source=github)** • **[Quickstart](https://distr.sh/docs/quickstart/?utm_source=github)** • **[Documentation](https://distr.sh/docs/?utm_source=github)** • **[Blog](https://distr.sh/blog/)** • **[Community](https://github.com/distr-sh/distr/discussions)**
 
 <hr>
 
@@ -79,7 +79,7 @@ architecture-beta
 ## Self-hosting
 
 In case you get stuck, have questions, or need help, we're happy to support you,
-drop by our [Discord](https://discord.gg/6qqBSAWZfW).
+join our [community forum](https://github.com/distr-sh/distr/discussions).
 
 ### Docker
 

--- a/frontend/ui/src/app/components/side-bar/side-bar.component.html
+++ b/frontend/ui/src/app/components/side-bar/side-bar.component.html
@@ -530,11 +530,14 @@
       >
       subscription.
     </div>
-    To request access, reach out to us on
-    <a href="https://discord.gg/6qqBSAWZfW" target="_blank" class="text-gray-600 dark:text-gray-400 hover:underline"
-      >Discord</a
+    To request access,
+    <a
+      href="https://github.com/distr-sh/distr/discussions"
+      target="_blank"
+      class="text-gray-600 dark:text-gray-400 hover:underline"
+      >get help</a
     >
-    or by email at
+    in our community forum or email us at
     <a href="mailto:support@distr.sh" class="text-gray-600 dark:text-gray-400 hover:underline">support&#64;distr.sh</a>.
   </div>
 </ng-template>

--- a/frontend/ui/src/app/components/side-bar/side-bar.component.html
+++ b/frontend/ui/src/app/components/side-bar/side-bar.component.html
@@ -534,6 +534,7 @@
     <a
       href="https://github.com/distr-sh/distr/discussions"
       target="_blank"
+      rel="noopener noreferrer"
       class="text-gray-600 dark:text-gray-400 hover:underline"
       >get help</a
     >

--- a/frontend/ui/src/app/tutorials/agents/agents-tutorial.component.html
+++ b/frontend/ui/src/app/tutorials/agents/agents-tutorial.component.html
@@ -270,13 +270,14 @@
                       in Distr.
                     </p>
                     <p class="mt-1 text-sm">
-                      If you need any help or in case you have questions, don't hesitate to ask in
+                      If you need any help or in case you have questions, don't hesitate to
                       <a
-                        href="https://discord.gg/6qqBSAWZfW"
+                        href="https://github.com/distr-sh/distr/discussions"
                         target="_blank"
                         class="text-gray-600 dark:text-gray-400 hover:underline"
-                        >Discord</a
-                      >!
+                        >get help</a
+                      >
+                      in our community forum!
                     </p>
                     <p class="mt-1 text-sm">
                       When you are done, you can show us by dropping the URL of your hello-distr fork in the text field

--- a/frontend/ui/src/app/tutorials/agents/agents-tutorial.component.html
+++ b/frontend/ui/src/app/tutorials/agents/agents-tutorial.component.html
@@ -274,6 +274,7 @@
                       <a
                         href="https://github.com/distr-sh/distr/discussions"
                         target="_blank"
+                        rel="noopener noreferrer"
                         class="text-gray-600 dark:text-gray-400 hover:underline"
                         >get help</a
                       >

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -83,11 +83,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           label: 'GitHub',
           href: 'https://github.com/distr-sh/distr',
         },
-        {
-          icon: 'discord',
-          label: 'Discord',
-          href: 'https://discord.gg/6qqBSAWZfW',
-        },
       ],
       components: {
         // Components can be overwritten here

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -83,6 +83,11 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           label: 'GitHub',
           href: 'https://github.com/distr-sh/distr',
         },
+        {
+          icon: 'comment-alt',
+          label: 'GitHub Discussions',
+          href: 'https://github.com/distr-sh/distr/discussions',
+        },
       ],
       components: {
         // Components can be overwritten here

--- a/website/src/components/DistrFooter.astro
+++ b/website/src/components/DistrFooter.astro
@@ -144,11 +144,11 @@ const currentYear = new Date().getFullYear();
           </li>
           <li>
             <a
-              href="https://discord.gg/6qqBSAWZfW"
+              href="https://github.com/distr-sh/distr/discussions"
               target="_blank"
               rel="noopener noreferrer"
               class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors no-underline">
-              Discord
+              Community forum
             </a>
           </li>
           <li>
@@ -221,14 +221,6 @@ const currentYear = new Date().getFullYear();
             class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
             <span class="sr-only">GitHub</span>
             <Icon name="github" class="w-5 h-5" />
-          </a>
-          <a
-            href="https://discord.gg/6qqBSAWZfW"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors">
-            <span class="sr-only">Discord</span>
-            <Icon name="discord" class="w-5 h-5" />
           </a>
           <a
             href="https://linkedin.com/company/glasskube"

--- a/website/src/components/home/MetricsSection.astro
+++ b/website/src/components/home/MetricsSection.astro
@@ -18,9 +18,9 @@ const metrics = [
     icon: 'lucide:star',
   },
   {
-    value: '250+',
-    label: 'Discord members',
-    icon: 'lucide:users',
+    value: '20+',
+    label: 'Contributors',
+    icon: 'lucide:git-pull-request',
   },
 ];
 ---

--- a/website/src/content/blog/2025-02-17-distr-v1-release.mdx
+++ b/website/src/content/blog/2025-02-17-distr-v1-release.mdx
@@ -39,7 +39,7 @@ This feature enables and simplifies the management of environment variables in y
 
 ![env-management](../../assets/blog/2025-02-17-distr-1-1-release/docker-env-management.png)
 
-Have questions or feedback? Share your thoughts on [Discord](https://discord.gg/6qqBSAWZfW) or join request a [demo call](https://cal.glasskube.com/team/gk/demo?duration=30) here!
+Have questions or feedback? [Join the discussion](https://github.com/distr-sh/distr/discussions) or request a [demo call](https://cal.glasskube.com/team/gk/demo?duration=30)!
 
 ### Upgrading to v1.1
 
@@ -66,7 +66,7 @@ Would love to get your thoughts on the licensing feature and hear what else you 
 
 We'd love to hear your thoughts on this release! Share your feedback, ideas, or questions:
 
-- Join the [Discord server](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo call](https://cal.glasskube.com/team/gk/demo?duration=30)
 - Reach out on [LinkedIn](https://www.linkedin.com/company/glasskube) or Twitter
 

--- a/website/src/content/blog/2025-02-25-distr-v2-release.mdx
+++ b/website/src/content/blog/2025-02-25-distr-v2-release.mdx
@@ -70,7 +70,7 @@ If you don't already, be sure to follow us on LinkedIn to stay up to date on the
 
 We'd love to hear your thoughts on this release! Share your feedback, ideas, or questions:
 
-- Join the [Discord server](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo call](https://cal.glasskube.com/team/gk/demo?duration=30)
 - Reach out on [LinkedIn](https://www.linkedin.com/company/glasskube)
 

--- a/website/src/content/blog/2026-02-17-distr-alerts.mdx
+++ b/website/src/content/blog/2026-02-17-distr-alerts.mdx
@@ -60,5 +60,5 @@ If you're not using Distr yet and you're dealing with [software distribution](/g
 
 We'd love to hear your thoughts on this feature! Share your feedback, ideas, or questions:
 
-- Join the [Discord server](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo call](https://cal.glasskube.com/team/gk/demo?duration=30)

--- a/website/src/content/blog/2026-02-24-vulnerability-scanning.mdx
+++ b/website/src/content/blog/2026-02-24-vulnerability-scanning.mdx
@@ -73,5 +73,5 @@ If you're already using Distr, this is a straightforward extension of the versio
 
 Questions on the scanning setup, or have you already got this running? Come find us:
 
-- [Discord server](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo call](https://cal.glasskube.com/team/gk/demo?duration=30)

--- a/website/src/content/blog/2026-03-09-distr-logs-metrics.mdx
+++ b/website/src/content/blog/2026-03-09-distr-logs-metrics.mdx
@@ -74,5 +74,5 @@ If you're not using Distr yet and you ship software to [on-prem](/glossary/on-pr
 
 We'd love to hear how you're using this — and what would make it more useful.
 
-- Join the [Discord server](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo call](https://cal.glasskube.com/team/gk/demo?duration=30)

--- a/website/src/content/blog/2026-03-12-license-key.mdx
+++ b/website/src/content/blog/2026-03-12-license-key.mdx
@@ -56,4 +56,4 @@ License management is available on Pro and Enterprise plans:
 
 ---
 
-Questions or want to see it in action? Join us in [Discord](https://discord.gg/6qqBSAWZfW) or [book a demo](https://cal.glasskube.com/team/gk/demo?duration=30).
+Questions or want to see it in action? [Join the discussion](https://github.com/distr-sh/distr/discussions) or [book a demo](https://cal.glasskube.com/team/gk/demo?duration=30).

--- a/website/src/content/blog/2026-03-17-kubernetes-compatibility-matrix.mdx
+++ b/website/src/content/blog/2026-03-17-kubernetes-compatibility-matrix.mdx
@@ -87,5 +87,5 @@ If you're not using Distr yet and you're distributing Helm-based software to cus
 
 Using this already, or have questions about the setup?
 
-- [Discord server](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo call](https://cal.glasskube.com/team/gk/demo?duration=30)

--- a/website/src/content/blog/2026-03-30-support-bundles.mdx
+++ b/website/src/content/blog/2026-03-30-support-bundles.mdx
@@ -83,5 +83,5 @@ If you're not using Distr yet and you're tired of playing telephone with custome
 
 Questions, feedback, or war stories about debugging customer environments? We're around.
 
-- [Discord](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo](https://cal.glasskube.com/team/gk/demo?duration=30)

--- a/website/src/content/blog/2026-04-15-docker-compose-mount-config-files.mdx
+++ b/website/src/content/blog/2026-04-15-docker-compose-mount-config-files.mdx
@@ -296,5 +296,5 @@ If you are distributing Docker Compose applications to customer environments and
 
 Questions, feedback, or war stories about shipping configuration files to customer environments? We are around.
 
-- [Discord](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo](https://cal.glasskube.com/team/gk/demo?duration=30)

--- a/website/src/content/blog/distr-v1.4-release-post.mdx
+++ b/website/src/content/blog/distr-v1.4-release-post.mdx
@@ -90,7 +90,7 @@ Follow us on [LinkedIn](https://www.linkedin.com/company/glasskube) to stay up t
 
 We’d love to hear your thoughts on this release! Share your feedback, ideas, or questions:
 
-- Join the [Discord server](https://discord.gg/6qqBSAWZfW)
+- [Join the discussion](https://github.com/distr-sh/distr/discussions)
 - [Book a demo call](https://cal.glasskube.com/team/gk/demo?duration=30)
 - Reach out on [LinkedIn](https://www.linkedin.com/company/glasskube) or [Twitter](https://twitter.com/glasskube)
 

--- a/website/src/content/docs/docs/agents/overview/setup-on-macos.mdx
+++ b/website/src/content/docs/docs/agents/overview/setup-on-macos.mdx
@@ -117,7 +117,7 @@ If there are no errors related to Docker socket access, your setup is good to go
 
 ---
 
-With these steps, your macOS environment should be fully configured to run Distr agents without issues. If you encounter any problems, feel free to reach out to us on [Discord](https://discord.gg/6qqBSAWZfW) or via email at support@distr.sh.
+With these steps, your macOS environment should be fully configured to run Distr agents without issues. If you encounter any problems, feel free to [get help](https://github.com/distr-sh/distr/discussions) in our community forum or email us at support@distr.sh.
 
 ## Common Issues
 

--- a/website/src/content/docs/docs/getting-started/introduction/quickstart.mdx
+++ b/website/src/content/docs/docs/getting-started/introduction/quickstart.mdx
@@ -55,7 +55,6 @@ Upon completion, you'll be ready to:
 Visit the [Use cases](/docs/use-cases/fully-self-managed/) section to identify the scenario that best fits your end customers and begin implementing the most appropriate deployment model for them.
 
 <Aside type="tip">
-  Need more help? Join our [Community Discord
-  Server](https://discord.gg/6qqBSAWZfW) for assistance from our team and other
-  Distr users.
+  Need more help? [Get help](https://github.com/distr-sh/distr/discussions) in
+  our community forum from our team and other Distr users.
 </Aside>

--- a/website/src/content/docs/docs/integrations/github-actions.md
+++ b/website/src/content/docs/docs/integrations/github-actions.md
@@ -613,8 +613,8 @@ Now that you have automatic deployments set up, consider:
 - [Release Please Documentation](https://github.com/googleapis/release-please) - Automated release management
 - [Conventional Commits Specification](https://www.conventionalcommits.org/) - Commit message format for Release Please
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
-- [Distr Discord Community](https://discord.gg/6qqBSAWZfW)
+- [Distr Community Forum](https://github.com/distr-sh/distr/discussions)
 
 ---
 
-Have questions? Join our [Discord community](https://discord.gg/6qqBSAWZfW) or check out the [FAQs](/docs/faqs/).
+Have questions? [Get help](https://github.com/distr-sh/distr/discussions) in our community forum or check out the [FAQs](/docs/faqs/).

--- a/website/src/content/docs/docs/integrations/index.mdx
+++ b/website/src/content/docs/docs/integrations/index.mdx
@@ -26,4 +26,4 @@ Access Distr programmatically using our REST API and client libraries:
 
 ---
 
-Need help integrating Distr? Join our [Discord community](https://discord.gg/6qqBSAWZfW).
+Need help integrating Distr? [Get help](https://github.com/distr-sh/distr/discussions) in our community forum.

--- a/website/src/content/docs/docs/platform/index.mdx
+++ b/website/src/content/docs/docs/platform/index.mdx
@@ -51,4 +51,4 @@ Control user roles and permissions:
 
 ---
 
-Need help with the platform? Join our [Discord community](https://discord.gg/6qqBSAWZfW).
+Need help with the platform? [Get help](https://github.com/distr-sh/distr/discussions) in our community forum.

--- a/website/src/content/docs/docs/platform/support/kubernetes-compatibility-matrix.mdx
+++ b/website/src/content/docs/docs/platform/support/kubernetes-compatibility-matrix.mdx
@@ -177,8 +177,8 @@ You can fork or copy from the hello-distr repository to get started quickly, the
 - [CRDs-catalog](https://github.com/datreeio/CRDs-catalog) — Community-maintained catalog of CRD schemas for kubeconform
 - [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) — Official Kubernetes version support policy
 - [GitHub Actions Matrix Strategy](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) — Matrix build documentation
-- [Distr Discord Community](https://discord.gg/6qqBSAWZfW)
+- [Distr Community Forum](https://github.com/distr-sh/distr/discussions)
 
 ---
 
-Have questions? Join our [Discord community](https://discord.gg/6qqBSAWZfW) or check out the [FAQs](/docs/faqs/).
+Have questions? [Get help](https://github.com/distr-sh/distr/discussions) in our community forum or check out the [FAQs](/docs/faqs/).

--- a/website/src/content/docs/docs/platform/support/vulnerability-scanning.mdx
+++ b/website/src/content/docs/docs/platform/support/vulnerability-scanning.mdx
@@ -173,8 +173,8 @@ The script generates `vulnerability-scan.md` and `vulnerability-scan.json` in th
 - [distr-create-version-action GitHub Repository](https://github.com/distr-sh/distr-create-version-action) — GitHub Action documentation including the resources input
 - [osv-scanner](https://github.com/google/osv-scanner) — The open-source vulnerability scanner used under the hood
 - [CVSS Specification](https://www.first.org/cvss/) — Common Vulnerability Scoring System documentation
-- [Distr Discord Community](https://discord.gg/6qqBSAWZfW)
+- [Distr Community Forum](https://github.com/distr-sh/distr/discussions)
 
 ---
 
-Have questions? Join our [Discord community](https://discord.gg/6qqBSAWZfW) or check out the [FAQs](/docs/faqs/).
+Have questions? [Get help](https://github.com/distr-sh/distr/discussions) in our community forum or check out the [FAQs](/docs/faqs/).

--- a/website/src/content/docs/docs/self-hosting/index.mdx
+++ b/website/src/content/docs/docs/self-hosting/index.mdx
@@ -25,4 +25,4 @@ Optimize and maintain your self-hosted Distr instance:
 
 ---
 
-Questions about self-hosting? Join our [Discord community](https://discord.gg/6qqBSAWZfW) or check out the [documentation](/docs/).
+Questions about self-hosting? [Get help](https://github.com/distr-sh/distr/discussions) in our community forum or check out the [documentation](/docs/).

--- a/website/src/content/docs/privacy-policy.mdx
+++ b/website/src/content/docs/privacy-policy.mdx
@@ -33,7 +33,7 @@ We collect the following categories of personal data:
 
 - **Account Information**: Name, email, profile photo, organization
 - **Billing & Payment Details**: Payment method, billing address (handled via third-party processors)
-- **Support & Communication**: Emails, Discord messages, feedback forms
+- **Support & Communication**: Emails, community forum posts, feedback forms
 
 ### B. Information Collected Automatically
 


### PR DESCRIPTION
## Summary

- Removes all Discord links/references across docs, blog, in-app UI, and website chrome in preparation for shutting down the Discord community
- Replaces CTAs with context-appropriate wording: "Community forum" (README, CONTRIBUTING, footer), "Get help" (docs + in-app support), "Join the discussion" (blog post CTAs) — all pointing to https://github.com/distr-sh/distr/discussions
- Swaps the "250+ Discord members" homepage metric for "20+ Contributors" (feel free to refine the count)
- Removes Discord from the Starlight social config and the footer social icon strip
- Updates privacy policy wording: "Discord messages" -> "community forum posts"

## Wording rationale

Researched OSS projects that moved (or are primarily) on GitHub Discussions (Supabase, PostHog, Next.js). The platform-agnostic "Community forum" label sidesteps naming GitHub in every surface and is more brand-portable long-term. "Get help" and "Join the discussion" match the intent of each surface without sounding like a retreat from Discord.

## Out of scope

- Issue -> Discussion migration will be handled separately by @donna-pixel
- `CHANGELOG.md:2048` references Discord in a historical release note — intentionally left as-is (immutable changelog entry)

## Test plan

- [x] `pnpm build` in `website/` passes and `starlight-links-validator` reports all internal links valid
- [x] `pnpm format` run in `website/` and `frontend/ui/`
- [x] grep for `discord` returns only the historical `CHANGELOG.md` entry
- [ ] Reviewer sanity-check of footer, homepage metric card, and quickstart help banner in preview