### PR TITLE
perf(backend): optimize GetLatestDeploymentRevisionStatus query for low row count

### DIFF
--- a/internal/db/deployment_revision_status.go
+++ b/internal/db/deployment_revision_status.go
@@ -205,19 +205,16 @@ func GetLatestDeploymentRevisionStatus(
 ) (*types.DeploymentRevisionStatus, error) {
 	db := internalctx.GetDb(ctx)
 
-	revisionIDs, err := GetDeploymentRevisionIDs(ctx, deploymentID)
-	if err != nil {
-		return nil, err
-	}
-
 	rows, err := db.Query(
 		ctx,
 		`SELECT id, created_at, deployment_revision_id, type, message
 		FROM DeploymentRevisionStatus
-		WHERE deployment_revision_id = ANY(@revisionIDs)
+		WHERE deployment_revision_id = ANY(
+			SELECT id FROM DeploymentRevision WHERE deployment_id = @deploymentID
+		)
 		ORDER BY created_at DESC
 		LIMIT 1`,
-		pgx.NamedArgs{"revisionIDs": revisionIDs},
+		pgx.NamedArgs{"deploymentID": deploymentID},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query latest DeploymentRevisionStatus: %w", err)

--- a/internal/db/deployments.go
+++ b/internal/db/deployments.go
@@ -399,22 +399,3 @@ func GetDeploymentIDForRevisionID(ctx context.Context, revisionID uuid.UUID) (uu
 
 	return deploymentID, nil
 }
-
-func GetDeploymentRevisionIDs(ctx context.Context, deploymentID uuid.UUID) ([]uuid.UUID, error) {
-	db := internalctx.GetDb(ctx)
-	rows, err := db.Query(
-		ctx,
-		"SELECT id from DeploymentRevision WHERE deployment_id = @deploymentId",
-		pgx.NamedArgs{"deploymentId": deploymentID},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query DeploymentRevision IDs: %w", err)
-	}
-
-	deploymentRevisionIDs, err := pgx.CollectRows(rows, pgx.RowTo[uuid.UUID])
-	if err != nil {
-		return nil, fmt.Errorf("failed to scan DeploymentRevision IDs: %w", err)
-	}
-
-	return deploymentRevisionIDs, nil
-}

--- a/internal/migrations/sql/97_drop_deployment_revision_status_created_at_index.down.sql
+++ b/internal/migrations/sql/97_drop_deployment_revision_status_created_at_index.down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX DeploymentRevisionStatus_created_at_single ON DeploymentRevisionStatus (created_at DESC);

--- a/internal/migrations/sql/97_drop_deployment_revision_status_created_at_index.up.sql
+++ b/internal/migrations/sql/97_drop_deployment_revision_status_created_at_index.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX DeploymentRevisionStatus_created_at_single;


### PR DESCRIPTION
also drop index (added in migration 27) that could trick the query planner into doing a seq scan and since it is otherwise unused