### PR TITLE
fix: add status updates and error handling for helm install/upgrade processes

### DIFF
--- a/cmd/agent/kubernetes/main.go
+++ b/cmd/agent/kubernetes/main.go
@@ -142,6 +142,7 @@ func main() {
 		}
 
 		if installRequired {
+			pushStatus(ctx, "helm install in progress")
 			if deployment, err := RunHelmInstall(ctx, res.Namespace, *res.Deployment); err != nil {
 				logger.Error("helm upgrade failed", zap.Error(err))
 				pushErrorStatus(ctx, fmt.Errorf("helm upgrade failed: %w", err))
@@ -153,9 +154,24 @@ func main() {
 				pushStatus(ctx, "helm install succeeded")
 			}
 		} else if upgradeRequired {
+			pushStatus(ctx, "helm upgrade in progress")
 			if deployment, err := RunHelmUpgrade(ctx, res.Namespace, *res.Deployment); err != nil {
-				logger.Error("helm install failed", zap.Error(err))
-				pushErrorStatus(ctx, fmt.Errorf("helm install failed: %w", err))
+				logger.Error("helm upgrade failed", zap.Error(err))
+				// Helm Atomic rollback creates a new revision in the cluster. Sync the tracking
+				// secret so the next iteration's revision check passes and the agent retries.
+				if recovered, recoverErr := GetLatestHelmRelease(ctx, res.Namespace, *res.Deployment); recoverErr == nil {
+					synced := AgentDeployment{
+						ReleaseName:  currentDeployment.ReleaseName,
+						RevisionID:   res.Deployment.RevisionID,
+						HelmRevision: recovered.Version,
+					}
+					if saveErr := SaveDeployment(ctx, res.Namespace, synced); saveErr != nil {
+						logger.Warn("could not sync tracking secret after rollback", zap.Error(saveErr))
+					} else {
+						logger.Info("synced tracking secret after atomic rollback", zap.Int("helmRevision", recovered.Version))
+					}
+				}
+				pushErrorStatus(ctx, fmt.Errorf("helm upgrade failed: %w", err))
 			} else if err := SaveDeployment(ctx, res.Namespace, *deployment); err != nil {
 				logger.Error("could not save latest deployment", zap.Error(err))
 				pushErrorStatus(ctx, fmt.Errorf("could not save latest deployment: %w", err))

--- a/cmd/agent/kubernetes/main.go
+++ b/cmd/agent/kubernetes/main.go
@@ -144,8 +144,8 @@ func main() {
 		if installRequired {
 			pushStatus(ctx, "helm install in progress")
 			if deployment, err := RunHelmInstall(ctx, res.Namespace, *res.Deployment); err != nil {
-				logger.Error("helm upgrade failed", zap.Error(err))
-				pushErrorStatus(ctx, fmt.Errorf("helm upgrade failed: %w", err))
+				logger.Error("helm install failed", zap.Error(err))
+				pushErrorStatus(ctx, fmt.Errorf("helm install failed: %w", err))
 			} else if err := SaveDeployment(ctx, res.Namespace, *deployment); err != nil {
 				logger.Error("could not save latest deployment", zap.Error(err))
 				pushErrorStatus(ctx, fmt.Errorf("could not save latest deployment: %w", err))


### PR DESCRIPTION
Closes: https://github.com/distr-sh/distr/issues/2432

###   Behavior after this fix

  The agent adopts a stop-on-rollback policy: after Helm rejects a version and rolls back, the agent acknowledges the rolled-back state as stable and stops retrying that version autonomously. To trigger a new upgrade the operator must push a new
  (corrected) version from the hub.

  _Before:_
```
  OK     status check passed. 3 resources    ← last known good state
  ERROR  helm upgrade failed: context deadline exceeded
  ERROR  actual helm revision (3) is different from latest deployed by agent (1). bailing out
  ERROR  actual helm revision (3) is different from latest deployed by agent (1). bailing out
  ERROR  (repeats every 5s forever)
```

  _After:_
```
  OK     helm upgrade in progress
  ERROR  helm upgrade failed: context deadline exceeded    ← reported once
  OK     status check passed. 3 resources                 ← recovered
  OK     status check passed. 3 resources
```

  _Additional changes_

  - Added pushStatus("helm install in progress") and pushStatus("helm upgrade in progress") before each Helm operation so the hub reflects the operation state while it runs.
  - Fixed pre-existing typo: "helm upgrade failed" → "helm install failed" in the install error path.