### PR TITLE
fix(kubernetes-agent): handle Helm revision skew during rollback

### DIFF
--- a/cmd/agent/kubernetes/main.go
+++ b/cmd/agent/kubernetes/main.go
@@ -314,10 +314,12 @@ func runInstallOrUpgrade(
 				synced := NewAgentDeployment(deployment)
 				synced.State = StateFailed
 				synced.HelmRevision = util.PtrTo(recovered.Version())
-				if saveErr := SaveDeployment(ctx, namespace, synced); saveErr != nil {
+				if util.PtrEq(currentDeployment.HelmRevision, synced.HelmRevision) {
+					logger.Debug("tracking secret is already synced")
+				} else if saveErr := SaveDeployment(ctx, namespace, synced); saveErr != nil {
 					logger.Warn("could not sync tracking secret after rollback", zap.Error(saveErr))
 				} else {
-					logger.Info("synced tracking secret after atomic rollback", zap.Int("helmRevision", recovered.Version()))
+					logger.Info("synced tracking secret after rollback", zap.Int("helmRevision", recovered.Version()))
 				}
 			} else {
 				logger.Warn("could not get helm release after rollback", zap.Error(recoverErr))

--- a/cmd/agent/kubernetes/main.go
+++ b/cmd/agent/kubernetes/main.go
@@ -307,6 +307,21 @@ func runInstallOrUpgrade(
 		if err != nil {
 			logger.Error("upgrade error", zap.Error(err))
 			pushErrorStatus(ctx, deployment, fmt.Errorf("upgrade error: %w", err))
+			// When RollbackOnFailure is true, Helm creates a new revision after rollback.
+			// Sync the tracking secret so verifyLatestHelmRelease passes on the next iteration
+			// instead of entering an infinite "revision skew" bail-out loop.
+			if recovered, recoverErr := GetLatestHelmRelease(ctx, namespace, deployment); recoverErr == nil {
+				synced := NewAgentDeployment(deployment)
+				synced.State = StateFailed
+				synced.HelmRevision = util.PtrTo(recovered.Version())
+				if saveErr := SaveDeployment(ctx, namespace, synced); saveErr != nil {
+					logger.Warn("could not sync tracking secret after rollback", zap.Error(saveErr))
+				} else {
+					logger.Info("synced tracking secret after atomic rollback", zap.Int("helmRevision", recovered.Version()))
+				}
+			} else {
+				logger.Warn("could not get helm release after rollback", zap.Error(recoverErr))
+			}
 		} else {
 			logger.Info(successMessage)
 			pushRunningStatus(ctx, deployment, successMessage)


### PR DESCRIPTION
Closes: https://github.com/distr-sh/distr/issues/2432

###   Behavior after this fix

  The agent adopts a stop-on-rollback policy: after Helm rejects a version and rolls back, the agent acknowledges the rolled-back state as stable and stops retrying that version autonomously. To trigger a new upgrade the operator must push a new
  (corrected) version from the hub.

  _Before:_
```
  OK     status check passed. 3 resources    ← last known good state
  ERROR  helm upgrade failed: context deadline exceeded
  ERROR  actual helm revision for my-app (3) is different from latest deployed by agent (1)
  ERROR  actual helm revision for my-app (3) is different from latest deployed by agent (1)
  ERROR  (repeats every 5s forever)
```

  _After:_
```
  OK     helm operation in progress
  ERROR  upgrade error: helm upgrade failed: context deadline exceeded    ← reported once
  OK     status check passed. 3 resources                                ← recovered
  OK     status check passed. 3 resources
```