### PR TITLE
fix(frontend): fix `ngSubmit` trigger in "update deployment" dialog

### DIFF
--- a/frontend/ui/src/app/deployments/deployment-modal.component.ts
+++ b/frontend/ui/src/app/deployments/deployment-modal.component.ts
@@ -1,5 +1,5 @@
 import {Component, effect, inject, input, output, signal} from '@angular/core';
-import {FormControl, ReactiveFormsModule, Validators} from '@angular/forms';
+import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {DeploymentTarget, DeploymentWithLatestRevision} from '@distr-sh/distr-sdk';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faCircleExclamation, faShip} from '@fortawesome/free-solid-svg-icons';
@@ -47,7 +47,7 @@ import {
           </button>
         </div>
         <!-- Modal body -->
-        <form class="p-4 md:p-5" (ngSubmit)="saveDeployment()">
+        <form class="p-4 md:p-5" [formGroup]="deployFormWrapper" (ngSubmit)="saveDeployment()">
           @if (deploymentTarget().customerOrganization !== undefined && auth.isVendor()) {
             <div
               class="flex items-center p-4 mb-4 text-yellow-800 rounded-lg bg-yellow-50 dark:bg-gray-800 dark:text-yellow-300"
@@ -89,6 +89,10 @@ export class DeploymentModalComponent {
   private readonly deploymentTargets = inject(DeploymentTargetsService);
 
   protected readonly deployForm = new FormControl<DeploymentFormValue | undefined>(undefined, Validators.required);
+  /**
+   * This is required because ngSubmit only works on forms with a form group attached
+   */
+  protected readonly deployFormWrapper = new FormGroup({deployment: this.deployForm});
   protected readonly loading = signal(false);
 
   protected readonly faShip = faShip;


### PR DESCRIPTION
This is a regression from #2500. `ngSubmit` only works with `FormsModule` or if the `<form>` has a `formGroup`. 

I now understand why this was necessary: https://github.com/distr-sh/distr/pull/2500#discussion_r3310909812 :upside_down_face: 