### PR TITLE
docs: switch from yaml to json for openapi docs

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -203,7 +203,7 @@ jobs:
         run: |
           dist/distr-amd64 serve &
           curl --retry 10 --retry-delay 1 --retry-connrefused -sf "$DISTR_HOST/ready" || { echo "Hub did not become ready in time"; exit 1; }
-          curl $DISTR_HOST/docs/openapi.yaml -sf -o /dev/null || { echo "OpenAPI spec is not valid or not reachable at $DISTR_HOST/docs/openapi.yaml"; exit 1; }
+          curl $DISTR_HOST/docs/openapi.json -sf -o /dev/null || { echo "OpenAPI spec is not valid or not reachable at $DISTR_HOST/docs/openapi.json"; exit 1; }
           psql $DATABASE_URL -c "select version > 0, dirty from schema_migrations" --csv -t | grep "t,f"
         env:
           DATABASE_URL: postgres://test-user:test-password@localhost:5432/distr

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -74,6 +74,9 @@ func NewRouter(
 	openapiRouter := chiopenapi.NewRouter(
 		baseRouter,
 		option.WithTitle("Distr API Reference"),
+		// Serve the spec as JSON: the library marshals YAML with single-quoted scalars, which do not
+		// interpret escape sequences, so multi-line descriptions would render with literal "\n" in the UI.
+		option.WithSpecPath("/docs/openapi.json"),
 		option.WithDescription(apiDescription),
 		option.WithVersion(buildconfig.Version()),
 		option.WithSecurity("bearer", option.SecurityHTTPBearer("Bearer")),


### PR DESCRIPTION
This fixes newline and escape and formatting

see broken state at https://app.distr.sh/docs