### PR TITLE
docs: clarify license key revision behavior

### DIFF
--- a/website/src/content/docs/docs/platform/licenses/license-keys.mdx
+++ b/website/src/content/docs/docs/platform/licenses/license-keys.mdx
@@ -47,9 +47,9 @@ When you request a token for a license key, Distr generates a signed JWT. Your a
 />
 
 <Aside type="note">
-  Payload, Not Before, and Expires At are **locked after creation** and cannot
-  be changed. Only the name and description can be updated later. If you need
-  different claims or dates, create a new key.
+  The name and description can be updated at any time. If you need to change the
+  payload or dates, Distr generates a new license key — the original is not
+  modified. See [Editing a license key](#editing-a-license-key).
 </Aside>
 
 ## Payload
@@ -130,7 +130,11 @@ Your application is responsible for deciding what to do when verification fails 
 
 ## Editing a license key
 
-You can update the **name** and **description** of an existing license key. Payload, dates, and customer assignment cannot be changed after creation.
+You can update the **name** and **description** of an existing license key at any time.
+
+If you need to change the **payload**, **Not Before**, or **Expires At**, Distr generates a new license key with the updated values — the original is not modified. You can view all previously generated license keys in the **Revisions** section of the edit view.
+
+Because tokens are stateless JWTs verified offline, existing deployments are not automatically updated. To use the new license key, re-fetch the token from the portal and apply it to the customer's deployment.
 
 To edit: open the license key from the customer's detail view and click the **edit** (pen) icon.
 

--- a/website/src/content/docs/docs/platform/licenses/license-management.mdx
+++ b/website/src/content/docs/docs/platform/licenses/license-management.mdx
@@ -83,7 +83,9 @@ Your application verifies the token using the corresponding public key — no ca
 <Aside type="note">
   **Payload and dates are immutable after creation.** Once a license key is
   created, only the name and description can be changed. If you need different
-  claims or dates, create a new key.
+  claims or dates, Distr creates a new license key — the original remains
+  unchanged. You can view all previously generated license keys in the revision
+  history.
 </Aside>
 
 <Aside type="note">


### PR DESCRIPTION
## Summary

- Clarifies that payload and dates are immutable per token — updating them generates a new license key rather than modifying the existing one
- Notes that existing deployments are not automatically updated and the new token must be re-fetched and re-applied manually
- Removes outdated wording that said payload/dates "cannot be changed after creation" without explaining the revision mechanism
- Removes mention of customer assignment immutability from the editing section (unnecessary detail)