### PR TITLE
chore(deps): upgrade stripe-go to v86

### DIFF
--- a/cmd/hub/cmd/serve.go
+++ b/cmd/hub/cmd/serve.go
@@ -16,7 +16,7 @@ import (
 	"github.com/distr-sh/distr/internal/util"
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/cobra"
-	"github.com/stripe/stripe-go/v85"
+	"github.com/stripe/stripe-go/v86"
 )
 
 type ServeOptions struct{ Migrate bool }

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/samber/slog-zap/v2 v2.7.0
 	github.com/shirou/gopsutil/v4 v4.26.5
 	github.com/spf13/cobra v1.10.2
-	github.com/stripe/stripe-go/v85 v85.2.0
+	github.com/stripe/stripe-go/v86 v86.0.0
 	go.opentelemetry.io/collector/component v1.59.0
 	go.opentelemetry.io/collector/confmap v1.59.0
 	go.opentelemetry.io/collector/consumer v1.59.0
@@ -69,12 +69,6 @@ require (
 	k8s.io/kubectl v0.36.1
 	k8s.io/metrics v0.36.1
 	oras.land/oras-go/v2 v2.6.1
-)
-
-require (
-	github.com/goccy/go-yaml v1.19.2 // indirect
-	go.opentelemetry.io/collector/consumer/xconsumer v0.153.0 // indirect
-	go.opentelemetry.io/collector/receiver/xreceiver v0.153.0 // indirect
 )
 
 require (
@@ -178,6 +172,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
+	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
@@ -303,6 +298,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.153.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.153.0 // indirect
+	go.opentelemetry.io/collector/consumer/xconsumer v0.153.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.59.0 // indirect
 	go.opentelemetry.io/collector/filter v0.153.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.153.0 // indirect
@@ -310,6 +306,7 @@ require (
 	go.opentelemetry.io/collector/pipeline v1.59.0 // indirect
 	go.opentelemetry.io/collector/pipeline/xpipeline v0.153.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverhelper v0.153.0 // indirect
+	go.opentelemetry.io/collector/receiver/xreceiver v0.153.0 // indirect
 	go.opentelemetry.io/collector/scraper v0.153.0 // indirect
 	go.opentelemetry.io/collector/scraper/scraperhelper v0.153.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -681,8 +681,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stripe/stripe-go/v85 v85.2.0 h1:LomL8ulv13+y+nIKtFP48Cn/pCIZmi4IBz5qjdDn+FY=
-github.com/stripe/stripe-go/v85 v85.2.0/go.mod h1:5P+HGFenpWgak27T5Is6JMsmDfUC1yJnjhhmquz7kXw=
+github.com/stripe/stripe-go/v86 v86.0.0 h1:CdyHmNj/QnFR222gpRy9wA4LUd71gUXnDFnUPqT0d6o=
+github.com/stripe/stripe-go/v86 v86.0.0/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZjBaFj3HgFonKXUcwgJ4djLb6i42S3Q=

--- a/internal/billing/billing_portal.go
+++ b/internal/billing/billing_portal.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/distr-sh/distr/internal/util"
-	"github.com/stripe/stripe-go/v85"
-	"github.com/stripe/stripe-go/v85/billingportal/session"
+	"github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/billingportal/session"
 )
 
 type BillingPortalSessionParams struct {

--- a/internal/billing/price.go
+++ b/internal/billing/price.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/distr-sh/distr/internal/types"
-	"github.com/stripe/stripe-go/v85"
-	"github.com/stripe/stripe-go/v85/price"
+	"github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/price"
 )
 
 const (

--- a/internal/billing/subscription.go
+++ b/internal/billing/subscription.go
@@ -9,9 +9,9 @@ import (
 	"github.com/distr-sh/distr/internal/limit"
 	"github.com/distr-sh/distr/internal/types"
 	"github.com/distr-sh/distr/internal/util"
-	"github.com/stripe/stripe-go/v85"
-	checkoutsession "github.com/stripe/stripe-go/v85/checkout/session"
-	"github.com/stripe/stripe-go/v85/subscription"
+	"github.com/stripe/stripe-go/v86"
+	checkoutsession "github.com/stripe/stripe-go/v86/checkout/session"
+	"github.com/stripe/stripe-go/v86/subscription"
 )
 
 func GetSubscriptionType(subscription stripe.Subscription) (*types.SubscriptionType, error) {

--- a/internal/handlers/billing_subscription.go
+++ b/internal/handlers/billing_subscription.go
@@ -17,7 +17,7 @@ import (
 	"github.com/distr-sh/distr/internal/types"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"github.com/stripe/stripe-go/v85"
+	"github.com/stripe/stripe-go/v86"
 	"go.uber.org/zap"
 )
 

--- a/internal/handlers/license_templates.go
+++ b/internal/handlers/license_templates.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/oaswrap/spec/adapter/chiopenapi"
 	"github.com/oaswrap/spec/option"
-	"github.com/stripe/stripe-go/v85"
+	"github.com/stripe/stripe-go/v86"
 	"go.uber.org/zap"
 )
 

--- a/internal/handlers/webhook_stripe.go
+++ b/internal/handlers/webhook_stripe.go
@@ -19,8 +19,8 @@ import (
 	"github.com/distr-sh/distr/internal/types"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"github.com/stripe/stripe-go/v85"
-	"github.com/stripe/stripe-go/v85/webhook"
+	"github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/webhook"
 	"go.uber.org/zap"
 )
 

--- a/internal/handlers/webhook_stripe_vendor.go
+++ b/internal/handlers/webhook_stripe_vendor.go
@@ -20,8 +20,8 @@ import (
 	"github.com/distr-sh/distr/internal/util"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"github.com/stripe/stripe-go/v85"
-	"github.com/stripe/stripe-go/v85/webhook"
+	"github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/webhook"
 	"go.uber.org/zap"
 )
 

--- a/internal/licensetemplate/render.go
+++ b/internal/licensetemplate/render.go
@@ -8,7 +8,7 @@ import (
 	"text/template"
 
 	"github.com/distr-sh/distr/internal/types"
-	"github.com/stripe/stripe-go/v85"
+	"github.com/stripe/stripe-go/v86"
 )
 
 func RenderPayload(tmpl types.LicenseTemplate, sub stripe.Subscription) (json.RawMessage, error) {

--- a/internal/licensetemplate/render_test.go
+++ b/internal/licensetemplate/render_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/distr-sh/distr/internal/types"
 	. "github.com/onsi/gomega"
-	"github.com/stripe/stripe-go/v85"
+	"github.com/stripe/stripe-go/v86"
 )
 
 func subscriptionWithItems(items ...*stripe.SubscriptionItem) stripe.Subscription {


### PR DESCRIPTION
From https://github.com/stripe/stripe-go/blob/v86.0.0/CHANGELOG.md
> This release doesn't change the pinned API version; it still uses 2026-05-27.dahlia.
> 
> We're doing an out-of-band-major to update a field type that changed. If you're not using tax_details, this is a no-op release when compared with the last one. If you are using tax_details its type has changed slightly and you'll have to update your code when upgrading.

