### PR TITLE
fix(backend): prevent deleting a referenced secret or license key

### DIFF
--- a/frontend/ui/src/app/licenses/license-keys/license-keys.component.ts
+++ b/frontend/ui/src/app/licenses/license-keys/license-keys.component.ts
@@ -196,6 +196,17 @@ export class LicenseKeysComponent {
         filter((result) => result === true),
         switchMap(() => this.licenseKeysService.delete(license)),
         catchError((e) => {
+          if (e instanceof HttpErrorResponse && e.status === 409) {
+            const affected: AffectedDeployment[] = e.error?.affectedDeployments ?? [];
+            if (affected.length > 0) {
+              const names = affected.map((a) => a.deploymentTargetName).join(', ');
+              this.toast.error(
+                `Cannot delete: this license key is referenced by ${names}. Remove the reference from the deployment config first.`
+              );
+              return EMPTY;
+            }
+          }
+
           const msg = getFormDisplayedError(e);
           if (msg) {
             this.toast.error(msg);

--- a/frontend/ui/src/app/secrets/secrets.component.ts
+++ b/frontend/ui/src/app/secrets/secrets.component.ts
@@ -181,7 +181,7 @@ export class SecretsComponent {
           if (affected.length > 0) {
             const names = affected.map((a) => a.deploymentTargetName).join(', ');
             this.toast.error(
-              `Cannot delete: this license key is referenced by ${names}. Remove the reference from the deployment config first.`
+              `Cannot delete: this secret is referenced by ${names}. Remove the reference from the deployment config first.`
             );
             return;
           }

--- a/frontend/ui/src/app/secrets/secrets.component.ts
+++ b/frontend/ui/src/app/secrets/secrets.component.ts
@@ -175,8 +175,19 @@ export class SecretsComponent {
       try {
         await firstValueFrom(this.secretsService.delete(secret.id));
         this.refresh.emit();
-      } catch (error) {
-        const msg = getFormDisplayedError(error);
+      } catch (e) {
+        if (e instanceof HttpErrorResponse && e.status === 409) {
+          const affected: AffectedDeployment[] = e.error?.affectedDeployments ?? [];
+          if (affected.length > 0) {
+            const names = affected.map((a) => a.deploymentTargetName).join(', ');
+            this.toast.error(
+              `Cannot delete: this license key is referenced by ${names}. Remove the reference from the deployment config first.`
+            );
+            return;
+          }
+        }
+
+        const msg = getFormDisplayedError(e);
         if (msg) {
           this.toast.error(msg);
         }

--- a/internal/db/license_keys.go
+++ b/internal/db/license_keys.go
@@ -49,7 +49,7 @@ func GetLicenseKeysByScope(
 	customerOrganizationID *uuid.UUID,
 ) ([]types.LicenseKey, error) {
 	if customerOrganizationID != nil {
-		return GetLicenseKeysByCustomerOrgID(ctx, organizationID, *customerOrganizationID)
+		return GetLicenseKeysByCustomerOrgID(ctx, *customerOrganizationID, organizationID)
 	}
 	return nil, nil
 }

--- a/internal/db/license_keys.go
+++ b/internal/db/license_keys.go
@@ -40,8 +40,16 @@ func GetLicenseKeysForDeploymentTarget(
 	ctx context.Context,
 	dt types.DeploymentTarget,
 ) ([]types.LicenseKey, error) {
-	if dt.CustomerOrganizationID != nil {
-		return GetLicenseKeysByCustomerOrgID(ctx, *dt.CustomerOrganizationID, dt.OrganizationID)
+	return GetLicenseKeysByScope(ctx, dt.OrganizationID, dt.CustomerOrganizationID)
+}
+
+func GetLicenseKeysByScope(
+	ctx context.Context,
+	organizationID uuid.UUID,
+	customerOrganizationID *uuid.UUID,
+) ([]types.LicenseKey, error) {
+	if customerOrganizationID != nil {
+		return GetLicenseKeysByCustomerOrgID(ctx, organizationID, *customerOrganizationID)
 	}
 	return nil, nil
 }

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -69,13 +69,20 @@ func GetSecretsForDeploymentTarget(
 	ctx context.Context,
 	dt types.DeploymentTarget,
 ) ([]types.SecretWithUpdatedBy, error) {
-	if dt.CustomerOrganizationID != nil {
-		return GetSecretsForCustomer(ctx, *dt.CustomerOrganizationID)
-	} else {
-		return GetSecretsForOrganization(ctx, dt.OrganizationID)
-	}
+	return GetSecretsByScope(ctx, dt.OrganizationID, dt.CustomerOrganizationID)
 }
 
+func GetSecretsByScope(
+	ctx context.Context,
+	organizationID uuid.UUID,
+	customerOrganizationID *uuid.UUID,
+) ([]types.SecretWithUpdatedBy, error) {
+	if customerOrganizationID != nil {
+		return GetSecretsForCustomer(ctx, *customerOrganizationID)
+	} else {
+		return GetSecretsForOrganization(ctx, organizationID)
+	}
+}
 func GetSecretsForOrganization(
 	ctx context.Context,
 	organizationID uuid.UUID,

--- a/internal/db/secrets.go
+++ b/internal/db/secrets.go
@@ -83,6 +83,7 @@ func GetSecretsByScope(
 		return GetSecretsForOrganization(ctx, organizationID)
 	}
 }
+
 func GetSecretsForOrganization(
 	ctx context.Context,
 	organizationID uuid.UUID,

--- a/internal/handlers/affected_deployments.go
+++ b/internal/handlers/affected_deployments.go
@@ -15,7 +15,9 @@ import (
 	"github.com/google/uuid"
 )
 
-func updateSecretValuePatchFunc(secretKey string, newValue string) func([]types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy {
+func updateSecretValuePatchFunc(
+	secretKey string, newValue string,
+) func([]types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy {
 	return func(secrets []types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy {
 		patched := slices.Clone(secrets)
 		for i := range patched {

--- a/internal/handlers/affected_deployments.go
+++ b/internal/handlers/affected_deployments.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -14,6 +15,19 @@ import (
 	"github.com/google/uuid"
 )
 
+func updateSecretValuePatchFunc(secretKey string, newValue string) func([]types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy {
+	return func(secrets []types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy {
+		patched := slices.Clone(secrets)
+		for i := range patched {
+			if patched[i].Key == secretKey {
+				patched[i].Value = newValue
+				break
+			}
+		}
+		return patched
+	}
+}
+
 func findAffectedDeploymentsBySecret(
 	ctx context.Context,
 	orgID uuid.UUID,
@@ -21,19 +35,20 @@ func findAffectedDeploymentsBySecret(
 	newValue string,
 	customerOrgID *uuid.UUID,
 ) ([]api.AffectedDeployment, error) {
-	return findAffectedDeployments(ctx, orgID, customerOrgID, func(
-		secrets []types.SecretWithUpdatedBy,
-		licenseKeys []types.LicenseKey,
-	) ([]types.SecretWithUpdatedBy, []types.LicenseKey) {
-		patchedSecrets := slices.Clone(secrets)
-		for i := range patchedSecrets {
-			if patchedSecrets[i].Key == secretKey {
-				patchedSecrets[i].Value = newValue
+	return findAffectedDeployments(ctx, orgID, customerOrgID, updateSecretValuePatchFunc(secretKey, newValue), nil)
+}
+
+func updateLicenseKeyPatchFunc(updatedLicenseKey types.LicenseKey) func([]types.LicenseKey) []types.LicenseKey {
+	return func(licenseKeys []types.LicenseKey) []types.LicenseKey {
+		patched := slices.Clone(licenseKeys)
+		for i := range patched {
+			if patched[i].ID == updatedLicenseKey.ID {
+				patched[i] = updatedLicenseKey
 				break
 			}
 		}
-		return patchedSecrets, licenseKeys
-	})
+		return patched
+	}
 }
 
 func findAffectedDeploymentsByLicenseKey(
@@ -42,30 +57,31 @@ func findAffectedDeploymentsByLicenseKey(
 	customerOrgID uuid.UUID,
 	updatedLicenseKey types.LicenseKey,
 ) ([]api.AffectedDeployment, error) {
-	return findAffectedDeployments(ctx, orgID, &customerOrgID, func(
-		secrets []types.SecretWithUpdatedBy,
-		licenseKeys []types.LicenseKey,
-	) ([]types.SecretWithUpdatedBy, []types.LicenseKey) {
-		patchedLicenseKeys := slices.Clone(licenseKeys)
-		for i := range patchedLicenseKeys {
-			if patchedLicenseKeys[i].ID == updatedLicenseKey.ID {
-				patchedLicenseKeys[i] = updatedLicenseKey
-				break
-			}
-		}
-		return secrets, patchedLicenseKeys
-	})
+	return findAffectedDeployments(ctx, orgID, &customerOrgID, nil, updateLicenseKeyPatchFunc(updatedLicenseKey))
 }
 
 func findAffectedDeployments(
 	ctx context.Context,
 	orgID uuid.UUID,
 	customerOrgID *uuid.UUID,
-	patch func([]types.SecretWithUpdatedBy, []types.LicenseKey) ([]types.SecretWithUpdatedBy, []types.LicenseKey),
+	patchSecrets func([]types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy,
+	patchLicenseKeys func([]types.LicenseKey) []types.LicenseKey,
 ) ([]api.AffectedDeployment, error) {
 	targets, err := db.GetDeploymentTargetsByScope(ctx, orgID, customerOrgID)
 	if err != nil {
 		return nil, err
+	}
+	secrets, err := db.GetSecretsByScope(ctx, orgID, customerOrgID)
+	if err != nil {
+		return nil, err
+	} else if patchSecrets != nil {
+		secrets = patchSecrets(secrets)
+	}
+	licenseKeys, err := db.GetLicenseKeysByScope(ctx, orgID, customerOrgID)
+	if err != nil {
+		return nil, err
+	} else if patchLicenseKeys != nil {
+		licenseKeys = patchLicenseKeys(licenseKeys)
 	}
 
 	affected := make([]api.AffectedDeployment, 0)
@@ -74,21 +90,12 @@ func findAffectedDeployments(
 		if err != nil {
 			return nil, err
 		}
-		secrets, err := db.GetSecretsForDeploymentTarget(ctx, target)
-		if err != nil {
-			return nil, err
-		}
-		licenseKeys, err := db.GetLicenseKeysForDeploymentTarget(ctx, target)
-		if err != nil {
-			return nil, err
-		}
 
-		patchedSecrets, patchedLicenseKeys := patch(secrets, licenseKeys)
 		for _, deployment := range deployments {
 			if len(deployment.ValuesHash) != sha256.Size {
 				continue
 			}
-			newHash, err := deploymentvalues.RenderAndHash(&deployment, patchedSecrets, patchedLicenseKeys)
+			newHash, err := deploymentvalues.RenderAndHash(&deployment, secrets, licenseKeys)
 			if err != nil {
 				return nil, err
 			}
@@ -102,7 +109,91 @@ func findAffectedDeployments(
 			}
 		}
 	}
+
 	return affected, nil
+}
+
+func deleteSecretPatchFunc(secretID uuid.UUID) func([]types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy {
+	return func(secrets []types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy {
+		return slices.DeleteFunc(slices.Clone(secrets), func(s types.SecretWithUpdatedBy) bool {
+			return s.ID == secretID
+		})
+	}
+}
+
+func findDeploymentsReferencingSecret(
+	ctx context.Context,
+	orgID uuid.UUID,
+	secretID uuid.UUID,
+	customerOrgID *uuid.UUID,
+) ([]api.AffectedDeployment, error) {
+	return findReferencingDeployments(ctx, orgID, customerOrgID, deleteSecretPatchFunc(secretID), nil)
+}
+
+func deleteLicenseKeyPatchFunc(licenseKeyID uuid.UUID) func([]types.LicenseKey) []types.LicenseKey {
+	return func(licenseKeys []types.LicenseKey) []types.LicenseKey {
+		return slices.DeleteFunc(slices.Clone(licenseKeys), func(lk types.LicenseKey) bool {
+			return lk.ID == licenseKeyID
+		})
+	}
+}
+
+func findDeploymentsReferencingLicenseKey(
+	ctx context.Context,
+	orgID uuid.UUID,
+	customerOrgID uuid.UUID,
+	licenseKeyID uuid.UUID,
+) ([]api.AffectedDeployment, error) {
+	return findReferencingDeployments(ctx, orgID, &customerOrgID, nil, deleteLicenseKeyPatchFunc(licenseKeyID))
+}
+
+func findReferencingDeployments(
+	ctx context.Context,
+	orgID uuid.UUID,
+	customerOrgID *uuid.UUID,
+	patchSecrets func([]types.SecretWithUpdatedBy) []types.SecretWithUpdatedBy,
+	patchLicenseKeys func([]types.LicenseKey) []types.LicenseKey,
+) ([]api.AffectedDeployment, error) {
+	targets, err := db.GetDeploymentTargetsByScope(ctx, orgID, customerOrgID)
+	if err != nil {
+		return nil, err
+	}
+	secrets, err := db.GetSecretsByScope(ctx, orgID, customerOrgID)
+	if err != nil {
+		return nil, err
+	} else if patchSecrets != nil {
+		secrets = patchSecrets(secrets)
+	}
+	licenseKeys, err := db.GetLicenseKeysByScope(ctx, orgID, customerOrgID)
+	if err != nil {
+		return nil, err
+	} else if patchLicenseKeys != nil {
+		licenseKeys = patchLicenseKeys(licenseKeys)
+	}
+
+	referencing := make([]api.AffectedDeployment, 0)
+	for _, target := range targets {
+		deployments, err := db.GetDeploymentsForDeploymentTarget(ctx, target.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, deployment := range deployments {
+			_, err := deploymentvalues.RenderAndHash(&deployment, secrets, licenseKeys)
+			if errors.Is(err, deploymentvalues.ErrInvalidTemplate) {
+				referencing = append(referencing, api.AffectedDeployment{
+					DeploymentTargetID:   target.ID,
+					DeploymentTargetName: target.Name,
+					DeploymentID:         deployment.ID,
+					ApplicationName:      deployment.Application.Name,
+				})
+			} else if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return referencing, nil
 }
 
 func triggerAffectedDeployments(ctx context.Context, affected []api.AffectedDeployment) error {

--- a/internal/handlers/license_keys.go
+++ b/internal/handlers/license_keys.go
@@ -67,7 +67,8 @@ func LicenseKeysRouter(r chiopenapi.Router) {
 					With(option.Response(http.StatusConflict, api.AffectedDeploymentsConflictResponse{}))
 				r.Delete("/", deleteLicenseKey).
 					With(option.Description("Delete a license key")).
-					With(option.Request(LicenseKeyIDRequest{}))
+					With(option.Request(LicenseKeyIDRequest{})).
+					With(option.Response(http.StatusConflict, api.AffectedDeploymentsConflictResponse{}))
 			})
 	})
 }
@@ -425,7 +426,23 @@ func updatedLicenseKeyForRequest(
 func deleteLicenseKey(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := internalctx.GetLogger(ctx)
+	authCtx := auth.Authentication.Require(ctx)
 	licenseKey := internalctx.GetLicenseKey(ctx)
+
+	if licenseKey.CustomerOrganizationID != nil {
+		referencing, err := findDeploymentsReferencingLicenseKey(ctx, *authCtx.CurrentOrgID(), *licenseKey.CustomerOrganizationID, licenseKey.ID)
+		if err != nil {
+			log.Error("failed to check deployment references for license key", zap.Error(err))
+			sentry.GetHubFromContext(ctx).CaptureException(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		if len(referencing) > 0 {
+			RespondJSONWithStatus(w, http.StatusConflict,
+				api.AffectedDeploymentsConflictResponse{AffectedDeployments: referencing})
+			return
+		}
+	}
 
 	if err := db.DeleteLicenseKeyWithID(ctx, licenseKey.ID); err != nil {
 		log.Warn("error deleting license key", zap.Error(err))

--- a/internal/handlers/license_keys.go
+++ b/internal/handlers/license_keys.go
@@ -430,7 +430,8 @@ func deleteLicenseKey(w http.ResponseWriter, r *http.Request) {
 	licenseKey := internalctx.GetLicenseKey(ctx)
 
 	if licenseKey.CustomerOrganizationID != nil {
-		referencing, err := findDeploymentsReferencingLicenseKey(ctx, *authCtx.CurrentOrgID(), *licenseKey.CustomerOrganizationID, licenseKey.ID)
+		referencing, err := findDeploymentsReferencingLicenseKey(
+			ctx, *authCtx.CurrentOrgID(), *licenseKey.CustomerOrganizationID, licenseKey.ID)
 		if err != nil {
 			log.Error("failed to check deployment references for license key", zap.Error(err))
 			sentry.GetHubFromContext(ctx).CaptureException(err)

--- a/internal/handlers/secrets.go
+++ b/internal/handlers/secrets.go
@@ -233,7 +233,8 @@ func deleteSecretHandler() http.HandlerFunc {
 			return
 		}
 
-		existing, err := db.GetSecretByID(ctx, id, *auth.CurrentOrgID(), auth.CurrentCustomerOrgID(), auth.CurrentPartnerOrgID())
+		existing, err := db.GetSecretByID(
+			ctx, id, *auth.CurrentOrgID(), auth.CurrentCustomerOrgID(), auth.CurrentPartnerOrgID())
 		if err != nil {
 			if errors.Is(err, apierrors.ErrNotFound) {
 				http.Error(w, "secret not found", http.StatusNotFound)

--- a/internal/handlers/secrets.go
+++ b/internal/handlers/secrets.go
@@ -47,7 +47,8 @@ func SecretsRouter(r chiopenapi.Router) {
 
 			r.Delete("/", deleteSecretHandler()).
 				With(option.Description("Delete a secret")).
-				With(option.Request(api.DeleteSecretRequest{}))
+				With(option.Request(api.DeleteSecretRequest{})).
+				With(option.Response(http.StatusConflict, api.AffectedDeploymentsConflictResponse{}))
 		})
 	})
 }
@@ -229,6 +230,31 @@ func deleteSecretHandler() http.HandlerFunc {
 		id, err := uuid.Parse(r.PathValue("secretId"))
 		if err != nil {
 			http.Error(w, "invalid secret ID", http.StatusBadRequest)
+			return
+		}
+
+		existing, err := db.GetSecretByID(ctx, id, *auth.CurrentOrgID(), auth.CurrentCustomerOrgID(), auth.CurrentPartnerOrgID())
+		if err != nil {
+			if errors.Is(err, apierrors.ErrNotFound) {
+				http.Error(w, "secret not found", http.StatusNotFound)
+			} else {
+				internalctx.GetLogger(ctx).Error("failed to get secret", zap.Error(err))
+				sentry.GetHubFromContext(ctx).CaptureException(err)
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			}
+			return
+		}
+
+		referencing, err := findDeploymentsReferencingSecret(ctx, *auth.CurrentOrgID(), id, existing.CustomerOrganizationID)
+		if err != nil {
+			internalctx.GetLogger(ctx).Error("failed to check deployment references for secret", zap.Error(err))
+			sentry.GetHubFromContext(ctx).CaptureException(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+		if len(referencing) > 0 {
+			RespondJSONWithStatus(w, http.StatusConflict,
+				api.AffectedDeploymentsConflictResponse{AffectedDeployments: referencing})
 			return
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes delete behavior for secrets and license keys used in live deployment templates; mis-detection could block valid deletes or allow broken configs, but scope is limited to pre-delete checks without mutating deployments.
> 
> **Overview**
> **Delete protection** for secrets and customer-scoped license keys: the API now refuses deletion when deployment configs still reference them, returning **409** with `affectedDeployments` (same shape as update conflicts). Reference detection simulates removing the secret/key and treats template render failures (`ErrInvalidTemplate`) as “still referenced.”
> 
> **Supporting refactors:** `findAffectedDeployments` loads secrets and license keys once per org/customer scope via new `GetSecretsByScope` / `GetLicenseKeysByScope`, instead of fetching per deployment target. Delete handlers load the secret first and document the 409 response in OpenAPI.
> 
> **UI:** license key and secret delete flows handle **409** with a toast listing affected deployment target names and instructions to remove references first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728c3bb549686f9bd0dc585d03421e7119139070. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->