### PR TITLE
chore: add dashboard page for users of a partner organization

### DIFF
--- a/frontend/ui/src/app/app-logged-in.routes.ts
+++ b/frontend/ui/src/app/app-logged-in.routes.ts
@@ -187,7 +187,7 @@ export const routes: Routes = [
       {
         path: 'artifact-pulls',
         component: ArtifactPullsComponent,
-        canActivate: [requireVendor],
+        canActivate: [requireVendorOrPartner],
       },
       {
         path: 'customers',

--- a/frontend/ui/src/app/app-logged-in.routes.ts
+++ b/frontend/ui/src/app/app-logged-in.routes.ts
@@ -148,7 +148,7 @@ export const routes: Routes = [
       {
         path: 'dashboard',
         component: DashboardComponent,
-        canActivate: [requireVendor],
+        canActivate: [requireVendorOrPartner],
       },
       {
         path: 'home',

--- a/frontend/ui/src/app/app.routes.ts
+++ b/frontend/ui/src/app/app.routes.ts
@@ -88,10 +88,8 @@ const inviteComponentGuard: CanActivateFn = async () => {
 const baseRouteRedirectGuard: CanActivateFn = () => {
   const auth = inject(AuthService);
   const router = inject(Router);
-  if (auth.isVendor()) {
+  if (auth.isVendor() || auth.isPartner()) {
     return router.createUrlTree(['/dashboard']);
-  } else if (auth.isPartner()) {
-    return router.createUrlTree(['/deployments']);
   } else {
     return router.createUrlTree(['/home']);
   }

--- a/frontend/ui/src/app/components/dashboard/dashboard.component.ts
+++ b/frontend/ui/src/app/components/dashboard/dashboard.component.ts
@@ -3,10 +3,11 @@ import {takeUntilDestroyed, toSignal} from '@angular/core/rxjs-interop';
 import {ActivatedRoute, Router} from '@angular/router';
 import {FaIconComponent} from '@fortawesome/angular-fontawesome';
 import {faSpinner} from '@fortawesome/free-solid-svg-icons';
-import {catchError, combineLatestWith, first, map, of, shareReplay, switchMap} from 'rxjs';
+import {catchError, combineLatest, combineLatestWith, first, map, of, shareReplay, switchMap} from 'rxjs';
 import {ArtifactsByCustomerCardComponent} from '../../artifacts/artifacts-by-customer-card/artifacts-by-customer-card.component';
 import {DeploymentTargetDashboardCardComponent} from '../../deployments/deployment-target-card/deployment-target-dashboard-card.component';
 import {DeploymentTargetViewData} from '../../deployments/deployment-targets.component';
+import {AuthService} from '../../services/auth.service';
 import {DashboardService} from '../../services/dashboard.service';
 import {DeploymentTargetsMetricsService} from '../../services/deployment-target-metrics.service';
 import {DeploymentTargetsService} from '../../services/deployment-targets.service';
@@ -30,6 +31,7 @@ import {SupportBundle} from '../../types/support-bundle';
 export class DashboardComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly auth = inject(AuthService);
   private readonly toast = inject(ToastService);
   private readonly dashboardService = inject(DashboardService);
   private readonly featureFlags = inject(FeatureFlagService);
@@ -87,13 +89,12 @@ export class DashboardComponent implements OnInit {
   protected readonly faSpinner = faSpinner;
 
   ngOnInit() {
-    if (this.route.snapshot.queryParams?.['from'] === 'login') {
-      this.artifactsByCustomer$
+    if (this.route.snapshot.queryParams?.['from'] === 'login' && this.auth.isVendor()) {
+      combineLatest([this.artifactsByCustomer$, this.deploymentTargetsService.list()])
         .pipe(
-          combineLatestWith(this.deploymentTargetsService.list()),
           first(),
-          switchMap(([artifacts, dts]) => {
-            if (artifacts.length === 0 && dts.length === 0) {
+          switchMap(([artifacts, deploymentTargets]) => {
+            if (artifacts.length === 0 && deploymentTargets.length === 0) {
               return this.router.navigate(['tutorials']);
             } else {
               return this.router.navigate([this.router.url]);
@@ -101,6 +102,8 @@ export class DashboardComponent implements OnInit {
           })
         )
         .subscribe();
+    } else if (this.route.snapshot.queryParams?.['from'] === 'login') {
+      this.router.navigate([this.router.url]);
     } else if (this.route.snapshot.queryParams?.['from'] === 'new-org') {
       this.toast.success('New organization created successfully');
       this.router.navigate([this.router.url]);

--- a/frontend/ui/src/app/components/side-bar/side-bar.component.html
+++ b/frontend/ui/src/app/components/side-bar/side-bar.component.html
@@ -355,6 +355,20 @@
           <a
             (click)="sidebar.hide()"
             routerLinkActive="bg-gray-100 dark:bg-gray-700"
+            routerLink="/dashboard"
+            class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+            <fa-icon
+              [icon]="faDashboard"
+              size="lg"
+              class="pl-0.5 w-6 h-6 text-gray-400 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" />
+            <span class="ms-3">Dashboard</span>
+          </a>
+        </li>
+
+        <li>
+          <a
+            (click)="sidebar.hide()"
+            routerLinkActive="bg-gray-100 dark:bg-gray-700"
             routerLink="/deployments"
             class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
             <fa-icon

--- a/frontend/ui/src/app/components/side-bar/side-bar.component.html
+++ b/frontend/ui/src/app/components/side-bar/side-bar.component.html
@@ -380,17 +380,43 @@
         </li>
 
         <li>
-          <a
-            (click)="sidebar.hide()"
-            routerLinkActive="bg-gray-100 dark:bg-gray-700"
-            routerLink="/artifacts"
-            class="flex items-center p-2 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+          <button
+            type="button"
+            (click)="toggle(registrySubMenuOpen)"
+            class="flex items-center w-full p-2 text-base text-gray-900 transition duration-75 rounded-lg group hover:bg-gray-100 dark:text-white dark:hover:bg-gray-700"
+            aria-controls="dropdown-example">
             <fa-icon
               [icon]="faBox"
               size="lg"
               class="pl-0.5 w-6 h-6 text-gray-400 transition duration-75 dark:text-gray-400 group-hover:text-gray-900 dark:group-hover:text-white" />
-            <span class="ms-3">Artifacts</span>
-          </a>
+            <span class="flex-1 ms-3 text-left rtl:text-right whitespace-nowrap">Registry</span>
+            <fa-icon
+              [icon]="faChevronDown"
+              [class.rotate-x-180]="registrySubMenuOpen()"
+              class="transition duration-150 ease-in-out" />
+          </button>
+          @if (registrySubMenuOpen()) {
+            <ul class="space-y-1">
+              <li>
+                <a
+                  (click)="sidebar.hide()"
+                  routerLinkActive="bg-gray-100 dark:bg-gray-700"
+                  routerLink="/artifacts"
+                  class="flex items-center p-2 pl-4 ml-7 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+                  <span class="">Artifacts</span>
+                </a>
+              </li>
+              <li>
+                <a
+                  (click)="sidebar.hide()"
+                  routerLinkActive="bg-gray-100 dark:bg-gray-700"
+                  routerLink="/artifact-pulls"
+                  class="flex items-center p-2 pl-4 ml-7 text-gray-900 rounded-lg dark:text-white hover:bg-gray-100 dark:hover:bg-gray-700 group">
+                  <span class="">Downloads</span>
+                </a>
+              </li>
+            </ul>
+          }
         </li>
 
         @if (isLicensingFeatureEnabled()) {

--- a/internal/db/artifacts.go
+++ b/internal/db/artifacts.go
@@ -844,22 +844,31 @@ func EnsureArtifactTagLimitForInsert(ctx context.Context, orgID uuid.UUID) (bool
 func GetArtifactVersionPullFilterOptions(
 	ctx context.Context,
 	orgID uuid.UUID,
+	partnerOrganizationID *uuid.UUID,
 ) (*types.ArtifactVersionPullFilterOptions, error) {
 	db := internalctx.GetDb(ctx)
 	result := &types.ArtifactVersionPullFilterOptions{}
 
-	pullBaseJoin := ` FROM ArtifactVersionPull p
-		JOIN ArtifactVersion v ON v.id = p.artifact_version_id
-		JOIN Artifact a ON a.id = v.artifact_id`
-	args := pgx.NamedArgs{"orgId": orgID}
+	baseFromExpr := ` ArtifactVersionPull p` +
+		` JOIN ArtifactVersion v ON v.id = p.artifact_version_id` +
+		` JOIN Artifact a ON a.id = v.artifact_id `
+	baseWhereExpr := ` a.organization_id = @orgId AND (@isVendor OR co.partner_organization_id = @partnerOrgId) `
+
+	args := pgx.NamedArgs{
+		"orgId":        orgID,
+		"isVendor":     partnerOrganizationID == nil,
+		"partnerOrgId": partnerOrganizationID,
+	}
 
 	// Customer organizations
-	rows, err := db.Query(ctx,
-		`SELECT co.id, co.name`+pullBaseJoin+`
-			JOIN CustomerOrganization co ON co.id = p.customer_organization_id
-		WHERE a.organization_id = @orgId
-		GROUP BY co.id, co.name
-		ORDER BY co.name`, args)
+	rows, err := db.Query(
+		ctx,
+		`SELECT co.id, co.name FROM `+baseFromExpr+
+			` JOIN CustomerOrganization co ON co.id = p.customer_organization_id`+
+			` WHERE `+baseWhereExpr+
+			` GROUP BY co.id, co.name ORDER BY co.name`,
+		args,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not query customer organizations for filter options: %w", err)
 	}
@@ -868,12 +877,15 @@ func GetArtifactVersionPullFilterOptions(
 	}
 
 	// User accounts
-	rows, err = db.Query(ctx,
-		`SELECT u.id, COALESCE(NULLIF(u.name, ''), u.email) AS name`+pullBaseJoin+`
-			JOIN UserAccount u ON u.id = p.useraccount_id
-		WHERE a.organization_id = @orgId
-		GROUP BY u.id, u.name, u.email
-		ORDER BY name`, args)
+	rows, err = db.Query(
+		ctx,
+		`SELECT u.id, COALESCE(NULLIF(u.name, ''), u.email) AS name FROM `+baseFromExpr+
+			` JOIN UserAccount u ON u.id = p.useraccount_id`+
+			` LEFT JOIN CustomerOrganization co ON co.id = p.customer_organization_id`+
+			` WHERE `+baseWhereExpr+
+			` GROUP BY u.id, u.name, u.email ORDER BY name`,
+		args,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not query user accounts for filter options: %w", err)
 	}
@@ -882,12 +894,14 @@ func GetArtifactVersionPullFilterOptions(
 	}
 
 	// Remote addresses
-	rows, err = db.Query(ctx,
-		`SELECT p.remote_address`+pullBaseJoin+`
-		WHERE a.organization_id = @orgId
-			AND p.remote_address IS NOT NULL
-		GROUP BY p.remote_address
-		ORDER BY p.remote_address`, args)
+	rows, err = db.Query(
+		ctx,
+		`SELECT p.remote_address FROM `+baseFromExpr+
+			` LEFT JOIN CustomerOrganization co ON co.id = p.customer_organization_id`+
+			` WHERE `+baseWhereExpr+` AND p.remote_address IS NOT NULL`+
+			` GROUP BY p.remote_address ORDER BY p.remote_address`,
+		args,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not query remote addresses for filter options: %w", err)
 	}
@@ -896,11 +910,14 @@ func GetArtifactVersionPullFilterOptions(
 	}
 
 	// Artifacts
-	rows, err = db.Query(ctx,
-		`SELECT a.id, a.name`+pullBaseJoin+`
-		WHERE a.organization_id = @orgId
-		GROUP BY a.id, a.name
-		ORDER BY a.name`, args)
+	rows, err = db.Query(
+		ctx,
+		`SELECT a.id, a.name FROM `+baseFromExpr+
+			` LEFT JOIN CustomerOrganization co ON co.id = p.customer_organization_id`+
+			` WHERE `+baseWhereExpr+
+			` GROUP BY a.id, a.name ORDER BY a.name`,
+		args,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("could not query artifacts for filter options: %w", err)
 	}
@@ -915,6 +932,7 @@ func GetArtifactVersionPullVersionOptions(
 	ctx context.Context,
 	orgID uuid.UUID,
 	artifactID uuid.UUID,
+	partnerOrganizationID *uuid.UUID,
 ) ([]types.FilterOption, error) {
 	db := internalctx.GetDb(ctx)
 	rows, err := db.Query(ctx,
@@ -922,11 +940,18 @@ func GetArtifactVersionPullVersionOptions(
 		FROM ArtifactVersionPull p
 			JOIN ArtifactVersion v ON v.id = p.artifact_version_id
 			JOIN Artifact a ON a.id = v.artifact_id
+			LEFT JOIN CustomerOrganization co ON co.id = p.customer_organization_id
 		WHERE a.organization_id = @orgId
 			AND a.id = @artifactId
+			AND (@isVendor OR co.partner_organization_id = @partnerOrgId)
 		GROUP BY v.id, v.name
 		ORDER BY v.name`,
-		pgx.NamedArgs{"orgId": orgID, "artifactId": artifactID})
+		pgx.NamedArgs{
+			"orgId":        orgID,
+			"artifactId":   artifactID,
+			"isVendor":     partnerOrganizationID == nil,
+			"partnerOrgId": partnerOrganizationID,
+		})
 	if err != nil {
 		return nil, fmt.Errorf("could not query artifact version options: %w", err)
 	}
@@ -946,11 +971,14 @@ func GetArtifactVersionPulls(
 	conditions := []string{
 		"a.organization_id = @orgId",
 		"p.created_at < @before",
+		"(@isVendor OR co.partner_organization_id = @partnerOrgId)",
 	}
 	args := pgx.NamedArgs{
-		"orgId":  filter.OrgID,
-		"before": filter.Before,
-		"count":  filter.Count,
+		"orgId":        filter.OrgID,
+		"before":       filter.Before,
+		"count":        filter.Count,
+		"isVendor":     filter.PartnerOrganizationID == nil,
+		"partnerOrgId": filter.PartnerOrganizationID,
 	}
 
 	if !filter.After.IsZero() {

--- a/internal/db/deployment_target_metrics.go
+++ b/internal/db/deployment_target_metrics.go
@@ -30,9 +30,10 @@ func GetLatestDeploymentTargetMetrics(
 	ctx context.Context,
 	orgID uuid.UUID,
 	customerOrganizationID *uuid.UUID,
+	partnerOrganizationID *uuid.UUID,
 ) ([]types.DeploymentTargetMetrics, error) {
 	db := internalctx.GetDb(ctx)
-	isVendorUser := customerOrganizationID == nil
+	isVendorUser := customerOrganizationID == nil && partnerOrganizationID == nil
 
 	rows, err := db.Query(ctx,
 		`SELECT `+deploymentTargetMetricsOutputExpr+` FROM DeploymentTarget dt
@@ -48,12 +49,19 @@ func GetLatestDeploymentTargetMetrics(
 		LEFT JOIN DeploymentTargetDiskMetrics dtdm
 			ON dtm.id = dtdm.deployment_target_metrics_id
 		WHERE dt.organization_id = @orgId
-		AND (@isVendorUser OR dt.customer_organization_id = @customerOrganizationId)
+		AND (@isVendorUser
+			OR dt.customer_organization_id = @customerOrganizationId
+			OR co.partner_organization_id = @partnerOrganizationId)
 		AND dt.metrics_enabled = true
 		GROUP BY dtm.id, dtm.deployment_target_id, dtm.cpu_cores_millis, dtm.cpu_usage, dtm.memory_bytes, dtm.memory_usage,
 			co.name, dt.name
 		ORDER BY co.name, dt.name`,
-		pgx.NamedArgs{"orgId": orgID, "customerOrganizationId": customerOrganizationID, "isVendorUser": isVendorUser},
+		pgx.NamedArgs{
+			"orgId":                  orgID,
+			"customerOrganizationId": customerOrganizationID,
+			"partnerOrganizationId":  partnerOrganizationID,
+			"isVendorUser":           isVendorUser,
+		},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query DeploymentTargets: %w", err)

--- a/internal/handlers/artifact_pulls.go
+++ b/internal/handlers/artifact_pulls.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/distr-sh/distr/api"
+	"github.com/distr-sh/distr/internal/apierrors"
 	"github.com/distr-sh/distr/internal/auth"
 	internalctx "github.com/distr-sh/distr/internal/context"
 	"github.com/distr-sh/distr/internal/db"
@@ -28,7 +30,7 @@ func ArtifactPullsRouter(r chiopenapi.Router) {
 	r.WithOptions(option.GroupTags("Artifacts"))
 	r.Use(
 		middleware.RequireOrgAndRole,
-		middleware.RequireVendor,
+		middleware.RequireVendorOrPartner,
 	)
 	r.Get("/", getArtifactPullsHandler()).
 		With(option.Description("List artifact version pulls")).
@@ -57,17 +59,23 @@ func ArtifactPullsRouter(r chiopenapi.Router) {
 		With(option.Response(http.StatusOK, []byte{}))
 }
 
-func parseArtifactPullFilters(r *http.Request, orgID uuid.UUID) (types.ArtifactVersionPullFilter, error) {
+func parseArtifactPullFilters(w http.ResponseWriter, r *http.Request) (types.ArtifactVersionPullFilter, error) {
+	ctx := r.Context()
+	authInfo := auth.Authentication.Require(ctx)
 	filter := types.ArtifactVersionPullFilter{
-		OrgID:  orgID,
+		OrgID:  *authInfo.CurrentOrgID(),
 		Before: time.Now(),
 		Count:  50,
+	}
+	fail := func(err error) (types.ArtifactVersionPullFilter, error) {
+		respondArtifactPullFilterError(w, ctx, err)
+		return filter, err
 	}
 
 	if before, err := QueryParam(r, "before", ParseTimeFunc(time.RFC3339Nano)); errors.Is(err, ErrParamNotDefined) {
 		// use default
 	} else if err != nil {
-		return filter, fmt.Errorf("before must be a valid date")
+		return fail(apierrors.NewBadRequest("before must be a valid date"))
 	} else {
 		filter.Before = before
 	}
@@ -75,7 +83,7 @@ func parseArtifactPullFilters(r *http.Request, orgID uuid.UUID) (types.ArtifactV
 	if after, err := QueryParam(r, "after", ParseTimeFunc(time.RFC3339Nano)); errors.Is(err, ErrParamNotDefined) {
 		// use default
 	} else if err != nil {
-		return filter, fmt.Errorf("after must be a valid date")
+		return fail(apierrors.NewBadRequest("after must be a valid date"))
 	} else {
 		filter.After = after
 	}
@@ -83,9 +91,9 @@ func parseArtifactPullFilters(r *http.Request, orgID uuid.UUID) (types.ArtifactV
 	if count, err := QueryParam(r, "count", strconv.Atoi); errors.Is(err, ErrParamNotDefined) {
 		// use default
 	} else if err != nil {
-		return filter, fmt.Errorf("count must be a number")
+		return fail(apierrors.NewBadRequest("count must be a number"))
 	} else if count < 1 || count > 1000 {
-		return filter, fmt.Errorf("count must be between 1 and 1000")
+		return fail(apierrors.NewBadRequest("count must be between 1 and 1000"))
 	} else {
 		filter.Count = count
 	}
@@ -93,7 +101,7 @@ func parseArtifactPullFilters(r *http.Request, orgID uuid.UUID) (types.ArtifactV
 	if id, err := QueryParam(r, "customerOrganizationId", uuid.Parse); errors.Is(err, ErrParamNotDefined) {
 		// use default
 	} else if err != nil {
-		return filter, fmt.Errorf("customerOrganizationId must be a valid UUID")
+		return fail(apierrors.NewBadRequest("customerOrganizationId must be a valid UUID"))
 	} else {
 		filter.CustomerOrganizationID = &id
 	}
@@ -101,7 +109,7 @@ func parseArtifactPullFilters(r *http.Request, orgID uuid.UUID) (types.ArtifactV
 	if id, err := QueryParam(r, "userAccountId", uuid.Parse); errors.Is(err, ErrParamNotDefined) {
 		// use default
 	} else if err != nil {
-		return filter, fmt.Errorf("userAccountId must be a valid UUID")
+		return fail(apierrors.NewBadRequest("userAccountId must be a valid UUID"))
 	} else {
 		filter.UserAccountID = &id
 	}
@@ -113,7 +121,7 @@ func parseArtifactPullFilters(r *http.Request, orgID uuid.UUID) (types.ArtifactV
 	if id, err := QueryParam(r, "artifactId", uuid.Parse); errors.Is(err, ErrParamNotDefined) {
 		// use default
 	} else if err != nil {
-		return filter, fmt.Errorf("artifactId must be a valid UUID")
+		return fail(apierrors.NewBadRequest("artifactId must be a valid UUID"))
 	} else {
 		filter.ArtifactID = &id
 	}
@@ -121,23 +129,51 @@ func parseArtifactPullFilters(r *http.Request, orgID uuid.UUID) (types.ArtifactV
 	if id, err := QueryParam(r, "artifactVersionId", uuid.Parse); errors.Is(err, ErrParamNotDefined) {
 		// use default
 	} else if err != nil {
-		return filter, fmt.Errorf("artifactVersionId must be a valid UUID")
+		return fail(apierrors.NewBadRequest("artifactVersionId must be a valid UUID"))
 	} else {
 		filter.ArtifactVersionID = &id
 	}
 
+	if partnerOrgID := authInfo.CurrentPartnerOrgID(); partnerOrgID != nil {
+		filter.PartnerOrganizationID = partnerOrgID
+		if filter.CustomerOrganizationID != nil {
+			co, err := db.GetCustomerOrganizationByID(ctx, *filter.CustomerOrganizationID)
+			if err != nil {
+				if errors.Is(err, apierrors.ErrNotFound) {
+					return fail(apierrors.NewForbidden("customer is not assigned to your partner organization"))
+				}
+				return fail(err)
+			}
+			if !util.PtrEq(co.PartnerOrganizationID, partnerOrgID) {
+				return fail(apierrors.NewForbidden("customer is not assigned to your partner organization"))
+			}
+		}
+	}
+
 	return filter, nil
+}
+
+func respondArtifactPullFilterError(w http.ResponseWriter, ctx context.Context, err error) {
+	log := internalctx.GetLogger(ctx)
+	switch {
+	case errors.Is(err, apierrors.ErrBadRequest):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	case errors.Is(err, apierrors.ErrForbidden):
+		http.Error(w, err.Error(), http.StatusForbidden)
+	default:
+		log.Warn("could not parse artifact pull filters", zap.Error(err))
+		sentry.GetHubFromContext(ctx).CaptureException(err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
 }
 
 func getArtifactPullsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		log := internalctx.GetLogger(ctx)
-		authInfo := auth.Authentication.Require(ctx)
 
-		filter, err := parseArtifactPullFilters(r, *authInfo.CurrentOrgID())
+		filter, err := parseArtifactPullFilters(w, r)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
@@ -159,7 +195,7 @@ func getArtifactPullFilterOptionsHandler() http.HandlerFunc {
 		log := internalctx.GetLogger(ctx)
 		authInfo := auth.Authentication.Require(ctx)
 
-		opts, err := db.GetArtifactVersionPullFilterOptions(ctx, *authInfo.CurrentOrgID())
+		opts, err := db.GetArtifactVersionPullFilterOptions(ctx, *authInfo.CurrentOrgID(), authInfo.CurrentPartnerOrgID())
 		if err != nil {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			sentry.GetHubFromContext(ctx).CaptureException(err)
@@ -183,7 +219,12 @@ func getArtifactPullVersionOptionsHandler() http.HandlerFunc {
 			return
 		}
 
-		versions, err := db.GetArtifactVersionPullVersionOptions(ctx, *authInfo.CurrentOrgID(), artifactID)
+		versions, err := db.GetArtifactVersionPullVersionOptions(
+			ctx,
+			*authInfo.CurrentOrgID(),
+			artifactID,
+			authInfo.CurrentPartnerOrgID(),
+		)
 		if err != nil {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			sentry.GetHubFromContext(ctx).CaptureException(err)
@@ -202,9 +243,8 @@ func exportArtifactPullsHandler() http.HandlerFunc {
 		authInfo := auth.Authentication.Require(ctx)
 		org := authInfo.CurrentOrg()
 
-		filter, err := parseArtifactPullFilters(r, *authInfo.CurrentOrgID())
+		filter, err := parseArtifactPullFilters(w, r)
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 

--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -21,7 +21,7 @@ import (
 
 func DashboardRouter(r chiopenapi.Router) {
 	r.WithOptions(option.GroupHidden(true))
-	r.With(middleware.RequireVendor, middleware.RequireOrgAndRole).Group(func(r chiopenapi.Router) {
+	r.With(middleware.RequireVendorOrPartner, middleware.RequireOrgAndRole).Group(func(r chiopenapi.Router) {
 		r.Get("/artifacts-by-customer", getArtifactsByCustomer)
 	})
 }
@@ -30,7 +30,14 @@ func getArtifactsByCustomer(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := internalctx.GetLogger(ctx)
 	auth := auth.Authentication.Require(ctx)
-	if customers, err := db.GetCustomerOrganizationsByOrganizationID(ctx, *auth.CurrentOrgID()); err != nil {
+	var customers []types.CustomerOrganizationWithUsage
+	var err error
+	if partnerOrgID := auth.CurrentPartnerOrgID(); partnerOrgID != nil {
+		customers, err = db.GetCustomerOrganizationsByPartnerOrgID(ctx, *partnerOrgID)
+	} else {
+		customers, err = db.GetCustomerOrganizationsByOrganizationID(ctx, *auth.CurrentOrgID())
+	}
+	if err != nil {
 		log.Error("failed to get customers", zap.Error(err))
 		sentry.GetHubFromContext(ctx).CaptureException(err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/internal/handlers/deployment_target_metrics.go
+++ b/internal/handlers/deployment_target_metrics.go
@@ -31,6 +31,7 @@ func getLatestDeploymentTargetMetrics(w http.ResponseWriter, r *http.Request) {
 		ctx,
 		*auth.CurrentOrgID(),
 		auth.CurrentCustomerOrgID(),
+		auth.CurrentPartnerOrgID(),
 	); err != nil {
 		internalctx.GetLogger(ctx).Error("failed to get deployment target metrics", zap.Error(err))
 		sentry.GetHubFromContext(ctx).CaptureException(err)

--- a/internal/types/artifact_version_pull.go
+++ b/internal/types/artifact_version_pull.go
@@ -29,6 +29,7 @@ type ArtifactVersionPullFilterOptions struct {
 
 type ArtifactVersionPullFilter struct {
 	OrgID                  uuid.UUID
+	PartnerOrganizationID  *uuid.UUID
 	Before                 time.Time
 	After                  time.Time
 	Count                  int


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Expands partner access to dashboard and download logs with new authorization paths; incorrect partner scoping in SQL or filter validation could leak or hide cross-partner data.
> 
> **Overview**
> **Partners get the vendor-style dashboard** as their home: default login redirect and route guards now send partners to `/dashboard` and allow **Dashboard** and **artifact downloads** alongside existing partner pages. The partner sidebar adds **Dashboard** first and a **Registry** submenu (Artifacts + Downloads).
> 
> **Backend data is scoped to the partner’s customers** for dashboard cards and registry telemetry: `artifacts-by-customer` loads customers via the partner org; artifact pull list/filter/export and deployment target metrics apply `partner_organization_id` filters in SQL. Partner users hitting artifact pulls get **403** if they filter by a customer not assigned to them.
> 
> Vendor-only behavior is preserved where it matters (e.g. post-login **tutorials** redirect on the dashboard stays vendor-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fadce481a1d39157f4d899ff8c03e64d05350fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->