### PR TITLE
fix(frontend): fix support bundle text overflow on dashboard page

### DIFF
--- a/frontend/ui/src/app/support-bundles/dashboard-card/support-bundle-dashboard-card.component.html
+++ b/frontend/ui/src/app/support-bundles/dashboard-card/support-bundle-dashboard-card.component.html
@@ -3,7 +3,7 @@
   <div class="mx-4 my-3 flex items-center min-w-0">
     <div class="min-w-0">
       <a routerLink="/support-bundles" class="hover:underline">
-        <h3 class="font-bold leading-none truncate" [title]="customerName()">
+        <h3 class="font-bold truncate" [title]="customerName()">
           {{ customerName() }}
         </h3>
       </a>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single Tailwind class change on a dashboard card heading with no logic or data handling impact.
> 
> **Overview**
> Fixes support bundle customer name overflow on the dashboard by removing **`leading-none`** from the card title **`h3`**, so truncated names lay out correctly with **`truncate`** inside the flex **`min-w-0`** container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a649edd543796f5efc13e3f8db327ce9dccb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->