### PR TITLE
docs: always pull latest from main before starting new work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,7 @@ When adding new routes, ensure the OpenAPI spec remains valid. The `chiopenapi` 
 ## General rules
 
 - Always ensure this file is up-to-date.
+- Before starting new work (especially when creating a new branch or starting a new agent session), always pull the latest changes from `main` first (e.g. `git fetch origin main` and update your base branch), so that work is always based on the newest code.
 - Don't write any unnecessary comments that just explain the functionality below, if there is nothing special about it.
 - If a user requests you to do something differently, add the difference to a new rule / convention in this file
 - If you read code that doesn't follow these rules, please fix it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a rule to `CLAUDE.md` (under **General rules**) instructing that, before starting new work — especially when creating a new branch or starting a new agent session — we always pull the latest changes from `main` first, so work is always based on the newest code.

## Motivation

Requested so that agents don't start from a stale base branch, avoiding unnecessary merge conflicts and ensuring everyone builds on top of the most recent code.

## Changes

- `CLAUDE.md`: new bullet under **General rules** describing the "pull from `main` first" convention.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a91a9968-455d-4143-b474-da3c332cced4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a91a9968-455d-4143-b474-da3c332cced4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

