### PR TITLE
docs(website): license key name is not editable

### DIFF
--- a/website/src/content/docs/docs/platform/licenses/license-management.mdx
+++ b/website/src/content/docs/docs/platform/licenses/license-management.mdx
@@ -82,10 +82,9 @@ Your application verifies the token using the corresponding public key — no ca
 
 <Aside type="note">
   **Payload and dates are immutable after creation.** Once a license key is
-  created, only the name and description can be changed. If you need different
-  claims or dates, Distr creates a new license key — the original remains
-  unchanged. You can view all previously generated license keys in the revision
-  history.
+  created, only the description can be changed. If you need different claims or
+  dates, Distr creates a new license key — the original remains unchanged. You
+  can view all previously generated license keys in the revision history.
 </Aside>
 
 <Aside type="note">


### PR DESCRIPTION
## Summary

- The License Management docs incorrectly stated that "only the **name and description** can be changed" after a license key is created.
- The name is set at creation and is immutable: the backend `UpdateLicenseKeyRequest` has no `Name` field and only updates the description/template (`internal/handlers/license_keys.go`), and the frontend disables the name control in edit mode (`edit-license-key.component.ts`).
- Corrected the wording in `website/src/content/docs/docs/platform/licenses/license-management.mdx` to say only the description can be changed. The companion `license-keys.mdx` already documents this correctly.

## Test plan

- [x] `pnpm run lint` (prettier) passes
- [x] `pnpm run check` (astro check) passes — 0 errors/warnings/hints
- [x] `pnpm run build` passes — internal link validation OK

Made with [Cursor](https://cursor.com)