### PR TITLE
fix(backend): add restarting affected deployments on template-based license key updates

### DIFF
--- a/internal/handlers/affected_deployments.go
+++ b/internal/handlers/affected_deployments.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 
 	"github.com/distr-sh/distr/api"
-	"github.com/distr-sh/distr/internal/auth"
 	"github.com/distr-sh/distr/internal/db"
 	"github.com/distr-sh/distr/internal/deploymentvalues"
 	"github.com/distr-sh/distr/internal/types"
@@ -199,9 +198,11 @@ func findReferencingDeployments(
 	return referencing, nil
 }
 
-func triggerAffectedDeployments(ctx context.Context, affected []api.AffectedDeployment) error {
-	createdByUserID := auth.Authentication.Require(ctx).CurrentUserID()
-
+func triggerAffectedDeployments(
+	ctx context.Context,
+	affected []api.AffectedDeployment,
+	createdByUserID *uuid.UUID,
+) error {
 	byTarget := make(map[uuid.UUID][]api.AffectedDeployment)
 	for _, ad := range affected {
 		byTarget[ad.DeploymentTargetID] = append(byTarget[ad.DeploymentTargetID], ad)
@@ -230,7 +231,7 @@ func triggerAffectedDeployments(ctx context.Context, affected []api.AffectedDepl
 					affectedDeployment.DeploymentID, affectedDeployment.DeploymentTargetID)
 			}
 			request := deploymentRequestFromLatestRevision(target.Deployments[index])
-			request.CreatedByUserAccountID = &createdByUserID
+			request.CreatedByUserAccountID = createdByUserID
 			if err := setDeploymentRequestValuesHash(&request, secrets, licenseKeys); err != nil {
 				return err
 			}

--- a/internal/handlers/license_keys.go
+++ b/internal/handlers/license_keys.go
@@ -327,7 +327,7 @@ func updateLicenseKey(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		return triggerAffectedDeployments(ctx, affected)
+		return triggerAffectedDeployments(ctx, affected, new(authCtx.CurrentUserID()))
 	})
 
 	if err != nil {

--- a/internal/handlers/secrets.go
+++ b/internal/handlers/secrets.go
@@ -207,7 +207,7 @@ func updateSecretHandler() http.HandlerFunc {
 			if err != nil {
 				return err
 			}
-			return triggerAffectedDeployments(ctx, affected)
+			return triggerAffectedDeployments(ctx, affected, new(auth.CurrentUserID()))
 		})
 		if err != nil {
 			internalctx.GetLogger(ctx).Error("failed to update secret", zap.Error(err))

--- a/internal/handlers/webhook_stripe_vendor.go
+++ b/internal/handlers/webhook_stripe_vendor.go
@@ -196,6 +196,11 @@ func handleVendorStripeSubscription(ctx context.Context, orgID uuid.UUID, sub st
 		zap.Int("affectedDeployments", len(affected)),
 	)
 
+	// Run the license key revision creation and deployment triggers in a single
+	// transaction, so that if the deployment triggers fail, the license key
+	// revision is not created.
+	// We respond to the webhook with 500 if the transaction fails, so that Stripe
+	// will retry the webhook.
 	if err := db.RunTx(ctx, func(ctx context.Context) error {
 		if err := db.CreateLicenseKeyRevision(ctx, &revision); err != nil {
 			return err

--- a/internal/handlers/webhook_stripe_vendor.go
+++ b/internal/handlers/webhook_stripe_vendor.go
@@ -153,13 +153,13 @@ func handleVendorStripeSubscription(ctx context.Context, orgID uuid.UUID, sub st
 		notBefore = expiresAt
 	}
 
-	if licenseKey.NotBefore != nil && licenseKey.ExpiresAt != nil && licenseKey.Payload != nil {
+	// don't check notBefore because it is always time.Now()
+	if licenseKey.ExpiresAt != nil && licenseKey.Payload != nil {
 		payloadEqual, err := payloadsEqual(licenseKey.Payload, payload)
 		if err != nil {
 			return err
 		}
 		if payloadEqual &&
-			licenseKey.NotBefore.Equal(notBefore.UTC().Truncate(time.Second)) &&
 			licenseKey.ExpiresAt.Equal(expiresAt.UTC().Truncate(time.Second)) {
 			log.Info("license key revision unchanged, skipping", zap.Stringer("licenseKeyId", licenseKeyID))
 			return nil

--- a/internal/handlers/webhook_stripe_vendor.go
+++ b/internal/handlers/webhook_stripe_vendor.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/distr-sh/distr/api"
 	"github.com/distr-sh/distr/internal/apierrors"
 	"github.com/distr-sh/distr/internal/billing"
 	internalctx "github.com/distr-sh/distr/internal/context"
@@ -172,12 +173,35 @@ func handleVendorStripeSubscription(ctx context.Context, orgID uuid.UUID, sub st
 		Payload:      payload,
 	}
 
+	// Determine which deployments reference this license key and would render
+	// differently with the new revision, so they can be restarted. There is no
+	// authenticated user in the webhook context, so the resulting deployment
+	// revisions are created without a "created by" user.
+	var affected []api.AffectedDeployment
+	if licenseKey.CustomerOrganizationID != nil {
+		updatedLicenseKey := *licenseKey
+		updatedLicenseKey.NotBefore = &revision.NotBefore
+		updatedLicenseKey.ExpiresAt = &revision.ExpiresAt
+		updatedLicenseKey.Payload = revision.Payload
+		affected, err = findAffectedDeploymentsByLicenseKey(
+			ctx, orgID, *licenseKey.CustomerOrganizationID, updatedLicenseKey)
+		if err != nil {
+			return err
+		}
+	}
+
 	log.Info("creating license key revision from vendor stripe subscription",
 		zap.Stringer("licenseKeyId", licenseKeyID),
 		zap.Time("expiresAt", expiresAt),
+		zap.Int("affectedDeployments", len(affected)),
 	)
 
-	if err := db.CreateLicenseKeyRevision(ctx, &revision); err != nil {
+	if err := db.RunTx(ctx, func(ctx context.Context) error {
+		if err := db.CreateLicenseKeyRevision(ctx, &revision); err != nil {
+			return err
+		}
+		return triggerAffectedDeployments(ctx, affected, nil)
+	}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We previously introduced automatically restarting deployments when a secret value or license key is changed, but this was not yet implemented for license keys updated automatically from a license key template. 

### Testing

* Set up a license key with a template, in a stripe subscription add the licenseKeyId metadata field
* Create a deployment, referencing the license key by name in its values/env
* Update the stripe subscription
* Check that a new deployment revision has been created (can be seen in the new history sidebar)