### PR TITLE
fix(backend): add encoding organization ID in license key JWT 

### DIFF
--- a/.github/workflows/build-hub.yaml
+++ b/.github/workflows/build-hub.yaml
@@ -175,6 +175,7 @@ jobs:
             -X github.com/distr-sh/distr/internal/buildconfig.version=${{ github.ref_name }}
             -X github.com/distr-sh/distr/internal/buildconfig.commit=${{ steps.hash.outputs.sha_short }}
             -X github.com/distr-sh/distr/internal/buildconfig.edition=${{ matrix.edition.name }}
+            ${{ (matrix.edition.name == 'enterprise' && startsWith(github.ref, 'refs/tags/')) && format('-X github.com/distr-sh/distr/internal/license.organizationID={0} -X github.com/distr-sh/distr/internal/license.organizationScopeCutoff={1}', secrets.LICENSE_ORGANIZATION_ID, secrets.LICENSE_ORGANIZATION_SCOPE_CUTOFF) || '' }}
 
       - name: Build application (arm64)
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -187,6 +188,7 @@ jobs:
             -X github.com/distr-sh/distr/internal/buildconfig.version=${{ github.ref_name }}
             -X github.com/distr-sh/distr/internal/buildconfig.commit=${{ steps.hash.outputs.sha_short }}
             -X github.com/distr-sh/distr/internal/buildconfig.edition=${{ matrix.edition.name }}
+            ${{ matrix.edition.name == 'enterprise' && format('-X github.com/distr-sh/distr/internal/license.organizationID={0} -X github.com/distr-sh/distr/internal/license.organizationScopeCutoff={1}', secrets.LICENSE_ORGANIZATION_ID, secrets.LICENSE_ORGANIZATION_SCOPE_CUTOFF) || '' }}
 
       - name: Generate ephemeral license JWT (non-tag enterprise only)
         id: ephemeral-license

--- a/cmd/hub/cmd/license_generate.go
+++ b/cmd/hub/cmd/license_generate.go
@@ -53,8 +53,11 @@ func NewGenerateLicenseKeyCommand() *cobra.Command {
 	cmd.Flags().StringVar(&opts.ValidPeriod, "valid-period", "8760h", "Validity period")
 	cmd.Flags().BoolVar(&opts.NoSave, "no-save", false, "Skip saving the license key to the database")
 	cmd.MarkFlagsMutuallyExclusive("expires-at", "valid-period")
-	cmd.MarkFlagsRequiredTogether("organization-id", "customer-id", "name")
-	for _, f := range []string{"organization-id", "customer-id", "name"} {
+	// customer-id and name are only meaningful when the license key is persisted, so they are
+	// mutually exclusive with --no-save. organization-id may be used with --no-save to scope an
+	// ephemeral license key to an organization.
+	cmd.MarkFlagsRequiredTogether("customer-id", "name")
+	for _, f := range []string{"customer-id", "name"} {
 		cmd.MarkFlagsOneRequired("no-save", f)
 		cmd.MarkFlagsMutuallyExclusive("no-save", f)
 	}
@@ -89,13 +92,25 @@ func runGenerateLicenseKey(ctx context.Context, opts GenerateLicenseKeyOptions) 
 		}
 	}
 
+	var orgID uuid.UUID
+	if opts.OrgID != "" {
+		if p, err := uuid.Parse(opts.OrgID); err != nil {
+			return fmt.Errorf("invalid organization-id: %w", err)
+		} else {
+			orgID = p
+		}
+	} else if !opts.NoSave {
+		return fmt.Errorf("organization-id is required unless --no-save is set")
+	}
+
 	if opts.NoSave {
 		data := licensekey.LicenseKeyData{
-			LicenseKeyID: uuid.New(),
-			IssuedAt:     time.Now(),
-			NotBefore:    notBefore,
-			ExpiresAt:    expiresAt,
-			Payload:      json.RawMessage(opts.Payload),
+			LicenseKeyID:   uuid.New(),
+			OrganizationID: orgID,
+			IssuedAt:       time.Now(),
+			NotBefore:      notBefore,
+			ExpiresAt:      expiresAt,
+			Payload:        json.RawMessage(opts.Payload),
 		}
 		token, err := licensekey.GenerateToken(data, env.Host())
 		if err != nil {
@@ -120,12 +135,7 @@ func runGenerateLicenseKey(ctx context.Context, opts GenerateLicenseKeyOptions) 
 		license.Description = &opts.Description
 	}
 
-	if p, err := uuid.Parse(opts.OrgID); err != nil {
-		log.Error("invalid organization-id", zap.Error(err))
-		return err
-	} else {
-		license.OrganizationID = p
-	}
+	license.OrganizationID = orgID
 
 	if p, err := uuid.Parse(opts.CustomerOrgID); err != nil {
 		log.Error("invalid customer-id", zap.Error(err))

--- a/internal/license/doc.go
+++ b/internal/license/doc.go
@@ -22,5 +22,20 @@ A compatible Distr license key can be generated using the following JSON as a te
 
 After error-free initialization, a [LicenseData] object can be obtained via [GetLicenseData].
 If no public key is set at compile time, [GetLicenseData] always returns the default values for all limits.
+
+# Organization scoping
+
+A build can additionally be restricted to license keys that were issued for a specific Distr
+organization. This is controlled by two variables that are injected at compile time via -ldflags
+(similar to the internal/buildconfig variables):
+
+	-X github.com/distr-sh/distr/internal/license.organizationID=<organization uuid>
+	-X github.com/distr-sh/distr/internal/license.organizationScopeCutoff=<yyyy-mm-dd date>
+
+When organizationID is set, [Initialize] additionally verifies that the license key carries a
+matching organization ID claim (see licensekey.OrganizationIDClaimName). To stay backwards
+compatible with license keys minted before organization scoping was introduced, this check only
+applies to license keys whose "issued at" claim is newer than organizationScopeCutoff. When
+organizationID is empty, organization scoping is disabled.
 */
 package license

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/distr-sh/distr/internal/env"
+	"github.com/distr-sh/distr/internal/licensekey"
 	"github.com/distr-sh/distr/internal/limit"
 	"github.com/distr-sh/distr/internal/types"
 	"github.com/go-viper/mapstructure/v2"
@@ -44,6 +45,30 @@ var (
 )
 
 const licenseDataClaimName = "ld"
+
+var (
+	// organizationID, when set at build time via -ldflags, restricts this build to license
+	// keys that were issued for the given Distr organization. When empty, organization
+	// scoping is disabled and any otherwise valid license key is accepted.
+	organizationID string
+
+	// organizationScopeCutoff, when set at build time via -ldflags, is a yyyy-mm-dd date.
+	// Only license keys with an "issued at" claim newer than this date are validated
+	// against organizationID; keys issued at or before it are exempt for backwards
+	// compatibility with license keys minted before organization scoping was introduced.
+	organizationScopeCutoff string
+)
+
+var cachedOrgScopeCutoff = sync.OnceValues(func() (time.Time, error) {
+	if organizationScopeCutoff == "" {
+		return time.Time{}, nil
+	}
+	t, err := time.Parse(time.DateOnly, organizationScopeCutoff)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid organization scope cutoff %q: %w", organizationScopeCutoff, err)
+	}
+	return t, nil
+})
 
 // LicenseData is the parsed private claims from the license key JWT.
 type LicenseData struct {
@@ -111,6 +136,15 @@ func parseAndValidate(pubKeySrc func() (jwk.Key, error), licenseKey string) (*Li
 		return nil, fmt.Errorf("invalid license key: %w", err)
 	}
 
+	cutoff, err := cachedOrgScopeCutoff()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := validateOrganizationScope(token, organizationID, cutoff); err != nil {
+		return nil, err
+	}
+
 	var licenseDataMap map[string]any
 	if err := token.Get(licenseDataClaimName, &licenseDataMap); err != nil {
 		return nil, fmt.Errorf("invalid license key: %w", err)
@@ -128,4 +162,28 @@ func parseAndValidate(pubKeySrc func() (jwk.Key, error), licenseKey string) (*Li
 	}
 
 	return &licenseData, nil
+}
+
+// validateOrganizationScope ensures the license key was issued for the organization this build
+// is licensed to. It is a noop when no organization ID was configured at build time or when the
+// license key was issued at or before the configured cutoff (i.e. before organization scoping
+// was introduced).
+func validateOrganizationScope(token jwt.Token, expectedOrgID string, cutoff time.Time) error {
+	if expectedOrgID == "" {
+		return nil
+	}
+
+	issuedAt, ok := token.IssuedAt()
+	if !ok || !issuedAt.After(cutoff) {
+		return nil
+	}
+
+	var orgID string
+	if err := token.Get(licensekey.OrganizationIDClaimName, &orgID); err != nil {
+		return fmt.Errorf("invalid license key: missing organization ID claim")
+	} else if orgID != expectedOrgID {
+		return fmt.Errorf("invalid license key: organization ID mismatch")
+	}
+
+	return nil
 }

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -215,3 +215,67 @@ func TestParseAndValidate_ExpirationDate(t *testing.T) {
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(got.ExpirationDate).To(BeTemporally("~", expiration, time.Second))
 }
+
+func buildToken(t *testing.T, issuedAt time.Time, claims map[string]any) jwt.Token {
+	t.Helper()
+	b := jwt.NewBuilder()
+	if !issuedAt.IsZero() {
+		b = b.IssuedAt(issuedAt)
+	}
+	for k, v := range claims {
+		b = b.Claim(k, v)
+	}
+	tok, err := b.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+func TestValidateOrganizationScope(t *testing.T) {
+	cutoff := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	const orgID = "11111111-1111-1111-1111-111111111111"
+	const otherOrgID = "22222222-2222-2222-2222-222222222222"
+
+	t.Run("disabled when no organization configured", func(t *testing.T) {
+		g := NewWithT(t)
+		tok := buildToken(t, cutoff.Add(time.Hour), map[string]any{"org": otherOrgID})
+		g.Expect(validateOrganizationScope(tok, "", cutoff)).To(Succeed())
+	})
+
+	t.Run("exempt when issued before cutoff", func(t *testing.T) {
+		g := NewWithT(t)
+		tok := buildToken(t, cutoff.Add(-time.Hour), map[string]any{"org": otherOrgID})
+		g.Expect(validateOrganizationScope(tok, orgID, cutoff)).To(Succeed())
+	})
+
+	t.Run("exempt when issued at cutoff", func(t *testing.T) {
+		g := NewWithT(t)
+		tok := buildToken(t, cutoff, map[string]any{"org": otherOrgID})
+		g.Expect(validateOrganizationScope(tok, orgID, cutoff)).To(Succeed())
+	})
+
+	t.Run("exempt when no issued-at claim", func(t *testing.T) {
+		g := NewWithT(t)
+		tok := buildToken(t, time.Time{}, map[string]any{"org": otherOrgID})
+		g.Expect(validateOrganizationScope(tok, orgID, cutoff)).To(Succeed())
+	})
+
+	t.Run("accepts matching organization after cutoff", func(t *testing.T) {
+		g := NewWithT(t)
+		tok := buildToken(t, cutoff.Add(time.Hour), map[string]any{"org": orgID})
+		g.Expect(validateOrganizationScope(tok, orgID, cutoff)).To(Succeed())
+	})
+
+	t.Run("rejects mismatched organization after cutoff", func(t *testing.T) {
+		g := NewWithT(t)
+		tok := buildToken(t, cutoff.Add(time.Hour), map[string]any{"org": otherOrgID})
+		g.Expect(validateOrganizationScope(tok, orgID, cutoff)).To(HaveOccurred())
+	})
+
+	t.Run("rejects missing organization claim after cutoff", func(t *testing.T) {
+		g := NewWithT(t)
+		tok := buildToken(t, cutoff.Add(time.Hour), nil)
+		g.Expect(validateOrganizationScope(tok, orgID, cutoff)).To(HaveOccurred())
+	})
+}

--- a/internal/licensekey/jwt.go
+++ b/internal/licensekey/jwt.go
@@ -15,9 +15,14 @@ import (
 	"github.com/lestrrat-go/jwx/v3/jwt"
 )
 
+// OrganizationIDClaimName is the JWT claim under which the organization ID a license key
+// was issued for is encoded. It matches the claim the license package validates against.
+const OrganizationIDClaimName = "org"
+
 var registeredClaims = map[string]struct{}{
 	jwt.ExpirationKey: {}, jwt.NotBeforeKey: {}, jwt.IssuerKey: {},
 	jwt.SubjectKey: {}, jwt.AudienceKey: {}, jwt.IssuedAtKey: {},
+	OrganizationIDClaimName: {},
 }
 
 var ErrNoSigningKey = errors.New("no license key signing key configured")
@@ -43,11 +48,12 @@ func IsSigningKeyConfigured() bool {
 }
 
 type LicenseKeyData struct {
-	LicenseKeyID uuid.UUID
-	IssuedAt     time.Time
-	ExpiresAt    time.Time
-	NotBefore    time.Time
-	Payload      json.RawMessage
+	LicenseKeyID   uuid.UUID
+	OrganizationID uuid.UUID
+	IssuedAt       time.Time
+	ExpiresAt      time.Time
+	NotBefore      time.Time
+	Payload        json.RawMessage
 }
 
 func FromLicenseKey(lk types.LicenseKey) LicenseKeyData {
@@ -62,21 +68,23 @@ func FromLicenseKey(lk types.LicenseKey) LicenseKeyData {
 		notBefore = *lk.NotBefore
 	}
 	return LicenseKeyData{
-		LicenseKeyID: lk.ID,
-		IssuedAt:     issuedAt,
-		ExpiresAt:    expiresAt,
-		NotBefore:    notBefore,
-		Payload:      lk.Payload,
+		LicenseKeyID:   lk.ID,
+		OrganizationID: lk.OrganizationID,
+		IssuedAt:       issuedAt,
+		ExpiresAt:      expiresAt,
+		NotBefore:      notBefore,
+		Payload:        lk.Payload,
 	}
 }
 
 func FromLicenseKeyAndRevision(lk types.LicenseKey, r types.LicenseKeyRevision) LicenseKeyData {
 	return LicenseKeyData{
-		LicenseKeyID: lk.ID,
-		IssuedAt:     r.CreatedAt,
-		ExpiresAt:    r.ExpiresAt,
-		NotBefore:    r.NotBefore,
-		Payload:      r.Payload,
+		LicenseKeyID:   lk.ID,
+		OrganizationID: lk.OrganizationID,
+		IssuedAt:       r.CreatedAt,
+		ExpiresAt:      r.ExpiresAt,
+		NotBefore:      r.NotBefore,
+		Payload:        r.Payload,
 	}
 }
 
@@ -104,6 +112,10 @@ func generateToken(key jwk.Key, src LicenseKeyData, issuer string) (string, erro
 		IssuedAt(src.IssuedAt).
 		NotBefore(src.NotBefore).
 		Expiration(src.ExpiresAt)
+
+	if src.OrganizationID != uuid.Nil {
+		builder = builder.Claim(OrganizationIDClaimName, src.OrganizationID.String())
+	}
 
 	for k, v := range customClaims {
 		builder = builder.Claim(k, v)

--- a/internal/licensekey/jwt_test.go
+++ b/internal/licensekey/jwt_test.go
@@ -64,6 +64,57 @@ func TestGenerateToken(t *testing.T) {
 	g.Expect(plan).To(Equal("enterprise"))
 }
 
+func TestGenerateToken_OrganizationClaim(t *testing.T) {
+	g := NewWithT(t)
+	key := testKey(t)
+	now := time.Now().Truncate(time.Second)
+	expiresAt := now.Add(24 * time.Hour)
+	orgID := uuid.New()
+	licenseKey := types.LicenseKey{
+		ID:             uuid.New(),
+		OrganizationID: orgID,
+		CreatedAt:      now,
+		LastRevisedAt:  &now,
+		NotBefore:      &now,
+		ExpiresAt:      &expiresAt,
+		Payload:        json.RawMessage(`{}`),
+	}
+
+	token, err := generateToken(key, FromLicenseKey(licenseKey), "test-issuer")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	pubKey, _ := key.PublicKey()
+	parsed, err := jwt.Parse([]byte(token), jwt.WithKey(jwa.EdDSA(), pubKey))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var org string
+	g.Expect(parsed.Get(OrganizationIDClaimName, &org)).To(Succeed())
+	g.Expect(org).To(Equal(orgID.String()))
+}
+
+func TestGenerateToken_NoOrganizationClaimWhenUnset(t *testing.T) {
+	g := NewWithT(t)
+	key := testKey(t)
+	now := time.Now().Truncate(time.Second)
+	expiresAt := now.Add(24 * time.Hour)
+
+	token, err := generateToken(key, LicenseKeyData{
+		LicenseKeyID: uuid.New(),
+		IssuedAt:     now,
+		NotBefore:    now,
+		ExpiresAt:    expiresAt,
+		Payload:      json.RawMessage(`{}`),
+	}, "test-issuer")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	pubKey, _ := key.PublicKey()
+	parsed, err := jwt.Parse([]byte(token), jwt.WithKey(jwa.EdDSA(), pubKey))
+	g.Expect(err).ToNot(HaveOccurred())
+
+	var org string
+	g.Expect(parsed.Get(OrganizationIDClaimName, &org)).ToNot(Succeed())
+}
+
 func TestGenerateToken_ReservedClaimsStripped(t *testing.T) {
 	g := NewWithT(t)
 	key := testKey(t)

--- a/website/src/content/docs/docs/platform/licenses/license-keys.mdx
+++ b/website/src/content/docs/docs/platform/licenses/license-keys.mdx
@@ -71,7 +71,7 @@ Example payloads:
 }
 ```
 
-The payload must be a JSON object (not an array or primitive). The following field names are reserved by the JWT spec and cannot be used: `exp`, `nbf`, `iss`, `sub`, `aud`, `iat`.
+The payload must be a JSON object (not an array or primitive). The following field names are reserved and cannot be used: the JWT-standard claims `exp`, `nbf`, `iss`, `sub`, `aud`, `iat`, as well as the Distr-specific claim `org`.
 
 ## Getting the token
 
@@ -93,6 +93,7 @@ The token contains:
 - `iat`: issued at (when the key was created in Distr)
 - `nbf`: not before
 - `exp`: expiration
+- `org`: the UUID of your Distr organization that issued the license key
 - All fields from your payload as top-level claims
 
 ### Retrieving the public key


### PR DESCRIPTION
With this PR, we add `organizationId` to every the encoded license JWT. This effectively changes existing license keys, but it is a backwards-compatible change WRT decoded licenses. 

This PR also introduces checking the `organizationId` claim of the Distr license key after a cutoff date. The specific values for both can be specified as build arguments and the CI is set up such that both are taken from GitHub Actions secrets. Both are already set up.

After releasing and deploying this change to the primary instance, we have to update the `LICENSE_KEY` GitHub Actions secret because it will also need the `organizationId` claim after the cutoff date, otherwise CI builds will start failing.

### Testing this PR

Before checking out this branch:

* Ensure that there is a license key. There should be no `organizationId` in the decoded license

After checking out this branch:

* Check the same license from before. it should now have an `organizationId` claim.

More involved testing: put the public key from http://localhost:8080/api/public/v1/license-keys/public-key into the file `./internal/license/embedded/pubkey.pem` and run the app with the following additional ldflags: 
* `github.com/distr-sh/distr/internal/license.organizationID=<organizationId from your local instance>`
* `github.com/distr-sh/distr/internal/license.organizationScopeCutoff=<some date>`

The app should fail to start unless a valid `LICENSE_KEY` environment variable has been provided. if the `organizationScopeCutoff` is in the past, it should also fail if the provided `LICENSE_KEY` has no `organizationID`, otherwise it should start. 

Check `internal/license/doc.go` for correct fields for the license key