### PR TITLE
docs(website): document deployment history and version renaming

### DIFF
--- a/website/src/content/docs/docs/agents/overview/application.mdx
+++ b/website/src/content/docs/docs/agents/overview/application.mdx
@@ -117,6 +117,12 @@ If you are looking for a more automated and integrated experience in creating ne
   </TabItem>
 </Tabs>
 
+## Renaming Applications and Versions
+
+You can rename an application or any of its versions at any time from the application detail page. Click the edit icon next to the application name, or click a version name in the versions table, to edit it inline and save.
+
+Renaming only changes the display name shown in Distr - it does not affect existing deployments or the underlying artifacts.
+
 ## Next Steps
 
 Once you've created your application and added versions, you're ready to create deployments. See the [Create Deployment](/docs/agents/deployment/) guide for instructions on deploying your applications to customer environments.

--- a/website/src/content/docs/docs/agents/overview/deployment.mdx
+++ b/website/src/content/docs/docs/agents/overview/deployment.mdx
@@ -147,6 +147,19 @@ Simply navigate to the **Deployments** section and click on the **+ Deploy App**
 
 This will show you the same flow as above, where you can select your application and version to deploy, configure the deployment settings, and get the command to install both the agent and application.
 
+## Deployment History
+
+Distr keeps a full history of every deployment. Each time a deployment's version or configuration changes, a new revision is recorded, so you can always see what was deployed, when, and by whom.
+
+On the **Deployments** page, open the actions menu on a deployment and select **Deployment history**. A timeline opens listing every revision, newest first, with the application version, the user or organization that made the change, and the timestamp. The active revision is marked **(current)**.
+
+Select any revision to inspect its full configuration:
+
+- **Docker**: the environment variables and deployment mode used for that revision.
+- **Helm**: the values file, release name, and Helm options (wait strategy, rollback on failure, cleanup on failure, and force conflicts).
+
+This makes it easy to review how a customer's deployment was configured in the past and to troubleshoot changes over time.
+
 ## Related Guides
 
 - [Create an Application](/docs/agents/application/) - Learn how to create Docker and Helm applications


### PR DESCRIPTION
## Summary

Documents two recently shipped, previously undocumented user-facing features:

- **Deployment history** (`2.25.0`, #2706): new `## Deployment History` section in `deployment.mdx` explaining the revision timeline - how to open it via the deployment's actions menu, and what each revision shows (application version, author, timestamp, and the full past configuration for Docker/Helm).
- **Application & version renaming** (`2.25.1`, #2730): new `## Renaming Applications and Versions` section in `application.mdx` explaining inline editing of the application name and version names, and that it only affects the display name.

Both additions are intentionally brief (text-only, no new screenshots or sidebar changes) to avoid overloading the docs.

## Test plan

- [x] `astro check` passes (0 errors, 0 warnings across 80 files)
- [x] `prettier` reports both files as already formatted
- [x] Reviewer confirms wording matches the shipped UI (optionally add screenshots as a follow-up)
