### PR TITLE
build: improve mise task caching

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [settings]
 env_shell_expand = false
+task.output = "prefix"
 
 [tools]
 node = "26"
@@ -21,37 +22,43 @@ CGO_ENABLED = "0"
 [vars]
 ldflags = "-s -w -X github.com/distr-sh/distr/internal/buildconfig.version=$VERSION -X github.com/distr-sh/distr/internal/buildconfig.commit=$COMMIT"
 
-[tasks.sdk-deps]
-run = 'pnpm install'
-dir = "sdk/js"
-sources = ["sdk/js/package.json", "sdk/js/pnpm-lock.yaml"]
-
-[tasks.frontend-deps]
-run = 'pnpm install'
-depends = ["build:sdk"]
-sources = ["package.json", "pnpm-lock.yaml", "sdk/js/src/**/*"]
-
 [tasks.go-tidy]
 run = 'go mod tidy'
 
 [tasks."build:sdk"]
 run = ['pnpm run build', 'pnpm run docs']
 dir = "sdk/js"
-depends = ["sdk-deps"]
-sources = ["sdk/js/node_modules/**/*", "sdk/js/src/**/*"]
+sources = [
+  "sdk/js/src/**/*",
+  "sdk/js/package.json",
+]
 
 [tasks."build:frontend:dev"]
 run = 'pnpm build:dev'
-depends = ["frontend-deps"]
-sources = ["node_modules/**/*", "frontend/ui/**/*"]
+depends = ["build:sdk"]
+sources = [
+  "frontend/ui/**/*",
+  "!frontend/ui/src/data/*.json",
+  "package.json",
+]
 
 [tasks."build:frontend:community"]
 run = 'pnpm build:community'
-depends = ["frontend-deps"]
+depends = ["build:sdk"]
+sources = [
+  "frontend/ui/**/*",
+  "!frontend/ui/src/data/*.json",
+  "package.json",
+]
 
 [tasks."build:frontend:enterprise"]
 run = 'pnpm build:enterprise'
-depends = ["frontend-deps"]
+depends = ["build:sdk"]
+sources = [
+  "frontend/ui/**/*",
+  "!frontend/ui/src/data/*.json",
+  "package.json",
+]
 
 [tasks."build:hub:community"]
 run = 'go build -ldflags="{{vars.ldflags}} -X github.com/distr-sh/distr/internal/buildconfig.edition=community" -o dist/distr ./cmd/hub'
@@ -89,7 +96,7 @@ description = 'Run all Go tests'
 
 [tasks."test:frontend"]
 run = 'pnpm test'
-depends = ["frontend-deps"]
+depends = ["build:sdk"]
 description = 'Run all frontend tests'
 
 [tasks.test]


### PR DESCRIPTION
Task caching is currently broken, especially because of some changes in pnpm v11

* remove explicit install steps for pnpm since it does that automatically now
* improve sources config