### PR TITLE
chore(backend): add configurable limit for support bundle log limit

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -98,6 +98,7 @@ var (
 	metricsEnabled                          bool
 	metricsAddr                             string
 	metricsBearerToken                      *string
+	supportBundleLogTailLines               int
 )
 
 func Initialize() {
@@ -281,6 +282,9 @@ func Initialize() {
 	metricsEnabled = envutil.GetEnvParsedOrDefault("METRICS_ENABLED", strconv.ParseBool, false)
 	metricsAddr = envutil.GetEnvOrDefault("METRICS_ADDR", ":3000", envutil.GetEnvOpts{})
 	metricsBearerToken = envutil.GetEnvOrNil("METRICS_BEARER_TOKEN")
+	supportBundleLogTailLines = envutil.GetEnvParsedOrDefault(
+		"SUPPORT_BUNDLE_LOG_TAIL_LINES", envparse.PositiveNumber, 1000,
+	)
 }
 
 func DatabaseUrl() string {
@@ -614,4 +618,10 @@ func MetricsAddr() string {
 
 func MetricsBearerToken() *string {
 	return metricsBearerToken
+}
+
+// SupportBundleLogTailLines is the number of container log lines (per container)
+// collected by the support bundle collect script.
+func SupportBundleLogTailLines() int {
+	return supportBundleLogTailLines
 }

--- a/internal/envparse/envparse.go
+++ b/internal/envparse/envparse.go
@@ -35,6 +35,14 @@ func NonNegativeNumber(value string) (int, error) {
 	return parsed, err
 }
 
+func PositiveNumber(value string) (int, error) {
+	parsed, err := strconv.Atoi(value)
+	if err == nil && parsed <= 0 {
+		err = errors.New("number must be positive")
+	}
+	return parsed, err
+}
+
 func Float(value string) (float64, error) {
 	return strconv.ParseFloat(value, 64)
 }

--- a/internal/handlers/support_bundles_collect.go
+++ b/internal/handlers/support_bundles_collect.go
@@ -10,6 +10,7 @@ import (
 	internalctx "github.com/distr-sh/distr/internal/context"
 	"github.com/distr-sh/distr/internal/customdomains"
 	"github.com/distr-sh/distr/internal/db"
+	"github.com/distr-sh/distr/internal/env"
 	"github.com/distr-sh/distr/internal/mapping"
 	"github.com/distr-sh/distr/internal/supportbundle"
 	"github.com/distr-sh/distr/internal/types"
@@ -78,7 +79,9 @@ func getCollectScriptHandler() http.HandlerFunc {
 			return
 		}
 
-		script, err := supportbundle.GenerateCollectScript(baseURL, bundle.ID, bundleSecret, envVars)
+		script, err := supportbundle.GenerateCollectScript(
+			baseURL, bundle.ID, bundleSecret, envVars, env.SupportBundleLogTailLines(),
+		)
 		if err != nil {
 			log.Error("failed to generate collect script", zap.Error(err))
 			sentry.GetHubFromContext(ctx).CaptureException(err)
@@ -104,7 +107,7 @@ func uploadSupportBundleResourceHandler() http.HandlerFunc {
 			return
 		}
 
-		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MiB
+		// The request body size is limited by the requestSize middleware on the route.
 		if err := r.ParseMultipartForm(1 << 20); err != nil {
 			http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 			return

--- a/internal/resources/embedded/support-bundle/collect-script.sh
+++ b/internal/resources/embedded/support-bundle/collect-script.sh
@@ -241,10 +241,10 @@ if [ -n "$INCLUDED_CONTAINERS" ]; then
   echo "Collecting and uploading container logs..."
   while IFS="$(printf '\t')" read -r CID CNAME; do
     [ -z "$CID" ] && continue
-    CONTAINER_LOGS=$(docker logs --tail 1000 "$CID" 2>&1 || true)
+    CONTAINER_LOGS=$(docker logs --tail {{.LogTailLines}} "$CID" 2>&1 || true)
     if [ -n "$CONTAINER_LOGS" ]; then
       upload_resource "${CNAME}-container-logs" "$CONTAINER_LOGS"
-      echo "  Uploaded logs for $CNAME (last 1000 lines)"
+      echo "  Uploaded logs for $CNAME (last {{.LogTailLines}} lines)"
     else
       echo "  No logs available for $CNAME"
     fi

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -116,6 +116,7 @@ func ApiRouter(
 	prometheusCollector *prometheus.DistrCollector,
 ) func(r chiopenapi.Router) {
 	requestSize1MiB := chimiddleware.RequestSize(1024 * 1024)
+	requestSize10MiB := chimiddleware.RequestSize(10 * 1024 * 1024)
 	requestSize50MiB := chimiddleware.RequestSize(50 * 1024 * 1024)
 
 	return func(r chiopenapi.Router) {
@@ -208,7 +209,9 @@ func ApiRouter(
 				r.Group(func(r chiopenapi.Router) {
 					r.Use(
 						middleware.OTEL(tracers.Default()),
-						requestSize1MiB,
+						// Container logs (up to SUPPORT_BUNDLE_LOG_TAIL_LINES per container) can be sizeable,
+						// so allow a larger request body than the default.
+						requestSize10MiB,
 					)
 					r.Route("/support-bundle-collect", handlers.SupportBundleScriptRouter)
 				})

--- a/internal/supportbundle/script.go
+++ b/internal/supportbundle/script.go
@@ -15,14 +15,16 @@ func GenerateCollectScript(
 	bundleID uuid.UUID,
 	bundleSecret string,
 	envVars []types.SupportBundleConfigurationEnvVar,
+	logTailLines int,
 ) (string, error) {
 	apiBase := fmt.Sprintf("%s/api/v1/support-bundle-collect/%s", baseURL, bundleID.String())
 
 	data := map[string]any{
-		"BundleID": bundleID.String(),
-		"BaseURL":  apiBase,
-		"Token":    bundleSecret,
-		"EnvVars":  envVars,
+		"BundleID":     bundleID.String(),
+		"BaseURL":      apiBase,
+		"Token":        bundleSecret,
+		"EnvVars":      envVars,
+		"LogTailLines": logTailLines,
 	}
 
 	tmpl, err := resources.GetTemplate("support-bundle/collect-script.sh")

--- a/website/src/content/docs/docs/self-hosting/configuration.mdx
+++ b/website/src/content/docs/docs/self-hosting/configuration.mdx
@@ -89,6 +89,12 @@ See [Registry Configuration](/docs/registry/configuration/) for a feature overvi
 | `REGISTRY_UPSTREAM_SYNC_CRON`              | no                  | —       | Cron schedule for syncing tags from upstream registries (pull-through cache).      |
 | `REGISTRY_UPSTREAM_SYNC_TIMEOUT`           | no                  | `10m`   | Timeout for a single upstream sync run.                                            |
 
+## Support Bundles
+
+| Variable                        | Required | Default | Description                                                                                   |
+| ------------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------- |
+| `SUPPORT_BUNDLE_LOG_TAIL_LINES` | no       | `1000`  | Number of container log lines (per container) collected by the support bundle collect script. |
+
 ## Scheduled Jobs & Retention
 
 These control the built-in job scheduler and retention limits.


### PR DESCRIPTION
also increase the size limit per support bundle resource from 1MiB to 10MiB

docs updated

### Testing

first, make sure that you have a container that has a lot of logs

run the server with `SUPPORT_BUNDLE_LOG_TAIL_LINES=<some value>`, create and upload a support bundle

make sure that the support bundle resource has the right amount of logs