### PR TITLE
ci(website): add caching of LFS objects

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -22,6 +22,10 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: website-${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: website
@@ -36,7 +40,20 @@ jobs:
             website
             CHANGELOG.md
           sparse-checkout-cone-mode: false
-          lfs: true
+      - name: Restore LFS cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .git/lfs
+          key: website-lfs-${{ github.sha }}
+          restore-keys: website-lfs-
+      - name: Pull LFS objects
+        run: git lfs pull
+      - name: Save LFS cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .git/lfs
+          key: website-lfs-${{ github.sha }}
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: website/package.json


### PR DESCRIPTION
Somehow we used up all of the free LFS bandwidth quota in just a few days :confused: 

CI is most likely not the real culprit here, but it might still be worthwhile adding the LFS cache.

Cursor "summary":

## Summary

The org's Git LFS bandwidth quota was exhausted early in the July billing period. Billing usage data shows **8.26 GB of LFS bandwidth, 100% from the `distr` repo**, and once exhausted, checkouts fail with:

> batch response: This repository exceeded its LFS budget. The account responsible for the budget should increase it to restore access.

## Key finding: it was a burst, not the CI drip

LFS bandwidth was consumed almost entirely in two single-hour buckets (from `GET /organizations/distr-sh/settings/billing/usage`):

| Timestamp (UTC) | LFS bandwidth |
|---|---|
| 2026-07-01 01:00 | 0.39 GB |
| **2026-07-02 08:00** | **3.00 GB** |
| **2026-07-03 00:00** | **4.78 GB** |
| 2026-07-04 08:00-09:00 | 0.10 GB |
| 07-05 onward | ~0 (budget blocked / reporting lag) |

At ~41 MiB per full LFS pull, each spike is **~70-120 full downloads in a single hour**. The `Build Website` workflow (the only workflow using `lfs: true`) ran just **12 times on 07-02 and 6 times on 07-03** — it cannot account for the burst. Its real footprint is only the ~0.4 GB on 07-01.

## Ruled out

- **`distr` workflows:** only `website.yaml` uses `lfs: true`; it is not scheduled.
- **All other org repos** (`status`, `hello-distr`, `distr-create-version-action`, `.github`): none check out `distr-sh/distr` and none use LFS (`status` has 5-min crons but checks out its own repo).
- => No GitHub Actions workflow in the org caused the burst.

## Conclusion

The ~7.8 GB spike came from **direct Git LFS traffic against `distr` from outside GitHub Actions** (clone / `git lfs pull` / `git lfs fetch --all` from a person, external CI, mirror/backup, or Codespaces). The round-hour timing suggests automation. A single `git lfs fetch --all` pulls every historical version of the tracked images, so a couple of those (or a mirror with `lfs.fetchall`) would explain the two spikes.

Actor attribution is not possible via API on the current plan: the org audit-log API returns 404 (Git-event auditing requires Enterprise Cloud), and GitHub exposes no per-request LFS logs.

## Investigation checklist

- [ ] Review **Deploy keys** on `distr` (Settings -> Deploy keys) for unknown/mirror keys.
- [ ] Review **PATs / installed GitHub Apps** with access to `distr` for external CI/mirror/backup integrations.
- [ ] Check for **Codespaces / devcontainer prebuilds** that pull LFS.
- [ ] Check any **self-hosted CI** (Jenkins/GitLab mirror, etc.) cloning `distr` with LFS smudge enabled, especially anything on a daily cron near 00:00/08:00 UTC.
- [ ] Confirm the two spikes and watch for continued accrual on the **Billing -> Usage** graph once reporting catches up.
- [ ] Raise/restore the LFS budget to unblock CI in the meantime.

## Mitigations (separate from finding the culprit)

- [x] `website.yaml`: added `concurrency` cancellation + LFS object caching (restore on all branches, save only on `main`) to cut the workflow's ongoing footprint. (Note: does not address this month's burn.)
- [ ] Optional: make the website workflow degrade gracefully instead of hard-failing when the LFS budget is exhausted.
- [ ] Optional: drop `CHANGELOG.md` from the `website.yaml` trigger paths to stop release-please churn from re-running the LFS build.
