### PR TITLE
docs(website): update homepage video to new Distr overview

### DIFF
--- a/website/src/components/home/VideoSection.astro
+++ b/website/src/components/home/VideoSection.astro
@@ -7,12 +7,12 @@
     <h2
       class="text-2xl md:text-3xl lg:text-4xl font-bold text-center mb-8 md:mb-12"
       style="color: white;">
-      How to Deploy & Update Software in Customer Environments Without SSH
+      Ship self-hosted software with Distr
     </h2>
     <div class="relative w-full pb-[56.25%] h-0">
       <iframe
         class="absolute top-0 left-0 w-full h-full rounded-xl shadow-2xl border-0"
-        src="https://www.youtube-nocookie.com/embed/ozpFWrXlSj4"
+        src="https://www.youtube-nocookie.com/embed/kPHHB8RridI"
         title="YouTube video player"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowfullscreen></iframe>


### PR DESCRIPTION
Replaces the homepage YouTube embed with the new "Ship self-hosted software with Distr" video (https://youtu.be/kPHHB8RridI) and updates the section heading to match the new video title.

Made with [Cursor](https://cursor.com)