### PR TITLE
docs(website): update homepage video embed

### DIFF
--- a/website/src/components/home/VideoSection.astro
+++ b/website/src/components/home/VideoSection.astro
@@ -12,7 +12,7 @@
     <div class="relative w-full pb-[56.25%] h-0">
       <iframe
         class="absolute top-0 left-0 w-full h-full rounded-xl shadow-2xl border-0"
-        src="https://www.youtube-nocookie.com/embed/kPHHB8RridI"
+        src="https://www.youtube-nocookie.com/embed/bt7eymGKYio"
         title="YouTube video player"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         allowfullscreen></iframe>


### PR DESCRIPTION
## Summary
- Swap the homepage YouTube embed from `kPHHB8RridI` to `bt7eymGKYio` ([new Cut A](https://youtu.be/bt7eymGKYio))
- Heading unchanged — both videos share the title “Ship self-hosted software with Distr”

## Test plan
- [ ] Confirm homepage video section plays https://youtu.be/bt7eymGKYio
- [ ] Spot-check that blog/docs topic embeds were left alone